### PR TITLE
CASMCMS-7357: restrict CFS paths for system-compute role

### DIFF
--- a/kubernetes/cray-opa/files/policy_test.rego.tpl
+++ b/kubernetes/cray-opa/files/policy_test.rego.tpl
@@ -58,7 +58,7 @@ test_pxe {
 
 compute_auth = "Bearer {{ .computeToken }}"
 
-cfs_mock_path = "/apis/cfs/mock"
+cfs_mock_path = "/apis/cfs/components/mock"
 cps_mock_path = "/apis/v2/cps/mock"
 hbtb_mock_path = "/apis/hbtd/mock"
 nmd_mock_path = "/apis/v2/nmd/mock"
@@ -70,15 +70,14 @@ test_compute {
 
   # CFS - Allowed
 
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": cfs_mock_path, "headers": {"authorization": compute_auth}}}}}
-
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": cfs_mock_path, "headers": {"authorization": compute_auth}}}}}
-
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": cfs_mock_path, "headers": {"authorization": compute_auth}}}}}
 
   # CFS - Not Allowed
 
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": cfs_mock_path, "headers": {"authorization": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": cfs_mock_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": cfs_mock_path, "headers": {"authorization": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": cfs_mock_path, "headers": {"authorization": compute_auth}}}}}
 
   # CPS - Allowed
 
@@ -184,8 +183,6 @@ test_unauth_role {
 
 spire_correct_sub(sub) {
 
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": cfs_mock_path, "headers": {"authorization": sub}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": cfs_mock_path, "headers": {"authorization": sub}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": cfs_mock_path, "headers": {"authorization": sub}}}}}
 
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": cps_mock_path, "headers": {"authorization": sub}}}}}
@@ -208,9 +205,7 @@ spire_correct_sub(sub) {
 
   # Validate that we're not allowing any method with a valid aud through
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": cfs_mock_path, "headers": {"authorization": sub}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": cfs_mock_path, "headers": {"authorization": sub}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": cfs_mock_path, "headers": {"authorization": sub}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": cfs_mock_path, "headers": {"authorization": sub}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": cfs_mock_path, "headers": {"authorization": sub}}}}}
 }
 

--- a/kubernetes/cray-opa/templates/_policy.tpl
+++ b/kubernetes/cray-opa/templates/_policy.tpl
@@ -186,9 +186,7 @@ allowed_methods := {
       {"method": "POST",  "path": `^/apis/bss/.*$`},
   ],
   "system-compute": [
-    {"method": "GET",  "path": `^/apis/cfs/.*$`},
-    {"method": "HEAD",  "path": `^/apis/cfs/.*$`},
-    {"method": "PATCH",  "path": `^/apis/cfs/.*$`},
+    {"method": "PATCH",  "path": `^/apis/cfs/components/.*$`},
 
     {"method": "GET",  "path": `^/apis/v2/cps/.*$`},
     {"method": "HEAD",  "path": `^/apis/v2/cps/.*$`},


### PR DESCRIPTION
### Summary and Scope

Per LANL security findings, we do not need the system-compute
role to make GET/HEAD requests to the CFS API.

### Issues and Related PRs

* Resolves CASMCMS-7357

### Testing

Tested on:

* Gamora

Tests run manually with a compute token

```
Previous policy:
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X GET   https://api-gw-service-nmn.local/apis/cfs/components
200
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X HEAD  https://api-gw-service-nmn.local/apis/cfs/components
200
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X PATCH https://api-gw-service-nmn.local/apis/cfs/components
400
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X POST  https://api-gw-service-nmn.local/apis/cfs/components
403
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X GET   https://api-gw-service-nmn.local/apis/cfs/sessions
200
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X HEAD  https://api-gw-service-nmn.local/apis/cfs/sessions
200
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X PATCH https://api-gw-service-nmn.local/apis/cfs/sessions
405
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X POST  https://api-gw-service-nmn.local/apis/cfs/sessions
403

Updated Policy:
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X POST  https://api-gw-service-nmn.local/apis/cfs/sessions
403
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X HEAD  https://api-gw-service-nmn.local/apis/cfs/components
403
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X PATCH https://api-gw-service-nmn.local/apis/cfs/components
400
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X POST  https://api-gw-service-nmn.local/apis/cfs/components
403
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X GET   https://api-gw-service-nmn.local/apis/cfs/sessions
403
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X HEAD  https://api-gw-service-nmn.local/apis/cfs/sessions
403
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X PATCH https://api-gw-service-nmn.local/apis/cfs/sessions
405
nid000001:~ # curl -s -o /dev/dull -w "%{http_code}\n" -H "Authorization: Bearer ${TOKEN}" -X POST  https://api-gw-service-nmn.local/apis/cfs/sessions
403

```

### Risks and Mitigations

None.

Requires:

* Compute nodes
* Fresh install
* Platform upgrade
