### PR TITLE
CASMPET-4465: Update cray-opa version and configmap version to prep for release

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.24.0
 name: cray-opa
 description: Cray Open Policy Agent
 home: "cloud/cray-charts"
-version: 0.15.0
+version: 0.16.0

--- a/kubernetes/cray-opa/templates/deployment.yaml
+++ b/kubernetes/cray-opa/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         env:
           - name: POLICY_CONFIGMAP_VERSION
             # Change to force opa pods to restart and re-read ConfigMap.
-            value: "4"
+            value: "5"
           {{- if .Values.opa.httpTimeout }}
           - name: HTTP_SEND_TIMEOUT
             value: {{ .Values.opa.httpTimeout | quote }}


### PR DESCRIPTION
Updates the cray-opa chart version to prep for a release for
CSM-1.1.

There haven't been any releases from this GitHub repository yet.

The POLICY_CONFIGMAP_VERSION is updated to cause the OPA pods to
restart to pick up the changed policy.

The commits in the release:

```
git log origin/release/csm-1.1..origin/master --no-merges --topo-order --oneline

fcdbce0 CASMCMS-7357: restrict CFS paths for system-compute role (#3)
5d33778 Set codeowners
b5fc959 Hms remediation (#2)
2451954 Updates for github build
```