### PR TITLE
CASMPET-4706: Run Rego tests

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -18,6 +18,22 @@ pipeline {
     }
 
     stages {
+        stage("Test") {
+            parallel {
+                stage('Rego') {
+                    steps {
+                        sh "make rego_test"
+                    }
+                }
+
+                stage('Chart') {
+                    steps {
+                        sh "make chart_test"
+                    }
+                }
+            }
+        }
+
         stage("Build") {
             parallel {
                 stage('Chart') {

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ CHART_VERSION ?= local
 
 HELM_UNITTEST_IMAGE ?= quintush/helm-unittest:3.3.0-0.2.5
 
-all : chart
-chart: chart_setup chart_package chart_test
-
+all : test chart
+test: chart_test rego_test
+chart: chart_setup chart_package
 
 chart_setup:
 		mkdir -p ${CHART_PATH}/.packaged
@@ -18,3 +18,7 @@ chart_package:
 chart_test:
 		helm lint "${CHART_PATH}/${NAME}"
 		docker run --rm -v ${PWD}/${CHART_PATH}:/apps ${HELM_UNITTEST_IMAGE} -3 ${NAME}
+
+rego_test:
+	docker build -f ${CHART_PATH}/cray-opa/files/Dockerfile --tag cray-opa-test ${CHART_PATH}/cray-opa
+	docker run --rm -v ${PWD}/${CHART_PATH}/cray-opa:/mnt --entrypoint "/app/run_tests" cray-opa-test /mnt/templates/_policy.tpl /mnt/files/policy_test.rego.tpl

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 
 This repository contains the cray-opa Helm chart.
 
-See the cray-opa chart README for how to run the unit tests!
+See the Makefile for how to run the unit tests!


### PR DESCRIPTION
There were manual instructions to run the Rego tests. These
instructions are now encoded in the Makefile and run by Jenkins.