### PR TITLE
CASMCMS-7355: Add BOS to the OPA policy

### DIFF
--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -275,6 +275,8 @@ allowed_methods := {
       {"method": "HEAD",  "path": `^/apis/bss/boot/v1/bootscript.*$`},
   ],
   "system-compute": [
+    {"method": "PATCH",  "path": `^/apis/bos/v./components/.*$`},
+
     {"method": "PATCH",  "path": `^/apis/cfs/components/.*$`},
     {"method": "PATCH",  "path": `^/apis/cfs/v./components/.*$`},
 
@@ -379,6 +381,13 @@ role_perms = {
 
 {{- if .Values.opa.xnamePolicy.enabled }}
 spire_methods := {
+  "bos": [
+  {{- if .Values.opa.xnamePolicy.bos }}
+    {"method": "PATCH", "path": sprintf("^/apis/bos/v./components/%v$", [parsed_spire_token.xname])},
+  {{- else }}
+    {"method": "PATCH", "path": `^/apis/bos/v./components/.*$`},
+  {{- end }}
+  ],
   "cfs": [
   {{- if .Values.opa.xnamePolicy.cfs }}
     {"method": "PATCH", "path": sprintf("^/apis/cfs/components/%v$", [parsed_spire_token.xname])},
@@ -387,7 +396,6 @@ spire_methods := {
     {"method": "PATCH", `^/apis/cfs/components/.*$`},
     {"method": "PATCH", `^/apis/cfs/v./components/.*$`},
   {{- end }}
-
   ],
   "cps": [
     {"method": "GET",  "path": `^/apis/v2/cps/.*$`},
@@ -443,6 +451,9 @@ spire_methods := {
   {{- end }}
 }
 sub_match = {
+    "spiffe://shasta/compute/XNAME/workload/bos-state-reporter": spire_methods["bos"],
+    "spiffe://shasta/uan/XNAME/workload/bos-state-reporter": spire_methods["bos"],
+    "spiffe://shasta/ncn/XNAME/workload/bos-state-reporter": spire_methods["bos"],
     "spiffe://shasta/compute/XNAME/workload/cfs-state-reporter": spire_methods["cfs"],
     "spiffe://shasta/ncn/XNAME/workload/cfs-state-reporter": spire_methods["cfs"],
     "spiffe://shasta/compute/XNAME/workload/ckdump": spire_methods["ckdump"],
@@ -491,6 +502,9 @@ sub_match_heartbeat = {
 # From https://connect.us.cray.com/confluence/display/SKERN/Shasta+Compute+SPIRE+Security
 # This is an initial set, not yet expected to be complete.
 sub_match = {
+    "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/compute/workload/bos-state-reporter": allowed_methods["system-compute"],
+    "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/uan/workload/bos-state-reporter": allowed_methods["system-compute"],
+    "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/ncn/workload/bos-state-reporter": allowed_methods["system-compute"],
     "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/compute/workload/cfs-state-reporter": allowed_methods["system-compute"],
     "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/ncn/workload/cfs-state-reporter": allowed_methods["system-compute"],
     "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/compute/workload/ckdump": allowed_methods["ckdump"],

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -58,6 +58,7 @@ opa:
   logPost: False
   xnamePolicy:
     enabled: True
+    bos: True
     cfs: True
     heartbeat: False
     # ckdump and dvs needs logPost to be true in order to function properly


### PR DESCRIPTION
## Summary and Scope

The Boot Orchestration Service (BOS) client resident on a node will
report the state of the node as it boots. It needs a JWT from Spire to
authenticate to the gateway and PATCH its state.

The client is only allowed to PATCH the components endpoint for its
specific xname when the XNAME policy is true. Otherwise, any component
can PATCH the state of any other component, which is not safe.


_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs
CASMCMS-7355

## Testing

This has not been tested yet. I wanted to get the PR out for comments from @kburns-hpe to see if I had made any mistakes prior to testing it out.

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:
This has been tested on Mug, which has a CSM-1.0 installation. I altered the OPA and Spire policies to let the bos-state-reporter through, and the BOS spire-agent on the compute node was able to get a JWT.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
No


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

