### PR TITLE
PE-37952 Fix typo in WLM workload

### DIFF
--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -507,7 +507,7 @@ sub_match = {
     "spiffe://shasta/ncn/XNAME/workload/dvs-map": spire_methods["dvs"],
     "spiffe://shasta/compute/XNAME/workload/orca": spire_methods["dvs"],
     "spiffe://shasta/ncn/XNAME/workload/orca": spire_methods["dvs"],
-    "spiffe://shasta/ncn/XNAME/workload/wlm": spire_methods["wlm"],
+    "spiffe://shasta/compute/XNAME/workload/wlm": spire_methods["wlm"],
     {{- if not .Values.opa.requireHeartbeatToken }}
     "spiffe://shasta/compute/XNAME/workload/heartbeat": spire_methods["heartbeat"],
     "spiffe://shasta/ncn/XNAME/workload/heartbeat": spire_methods["heartbeat"]


### PR DESCRIPTION
## Summary and Scope

Fix an instance of the WLM workload that used ncn instead of compute.

## Issues and Related PRs

* Found while testing PE-37952

## Testing

### Tested on:

  * Local development environment

### Test description:

Tested with unit tests.

## Risks and Mitigations

No known risks

## Pull Request Checklist

- [n/a ] Version number(s) incremented, if applicable
- [n/a ] Copyrights updated
- [x ] License file intact
- [x ] Target branch correct
- [n/a ] CHANGELOG.md updated
- [x ] Testing is appropriate and complete, if applicable
- [n/a ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

