### PR TITLE
Bump cray-opa to 1.3.0

### DIFF
--- a/kubernetes/cray-opa/CHANGELOG.md
+++ b/kubernetes/cray-opa/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [1.3.0]
+### Changed
+- Added entries for BOS (CASMCMS-7355)
+- Added support for custom issuers per OPA policy (CASMPET-5150)
+- Fixed WLM workload Spiffe ID (PE-37951)
+- Replaced problematic xname validation support in POST requests with new API endpoints (CASMPET-3940)
+- Removed unused HMN OPA Policy (CASMPET-4141)

--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -3,5 +3,4 @@ appVersion: 0.24.0
 name: cray-opa
 description: Cray Open Policy Agent
 home: "cloud/cray-charts"
-version: 1.2.0
-
+version: 1.3.0


### PR DESCRIPTION
## Summary and Scope

Releasing cray-opa version 1.3.0 for CSM 1.2

## Issues and Related PRs

* Resolves [CASMCMS-7355](https://connect.us.cray.com/jira/browse/CASMCMS-7355)
* Resolves [CASMPET-3940](https://connect.us.cray.com/jira/browse/CASMPET-3940)
* Resolves [CASMPET-4141](https://connect.us.cray.com/jira/browse/CASMPET-4141)
* Resolves [CASMPET-5150](https://connect.us.cray.com/jira/browse/CASMPET-5150)
* Resolves [PE-37951](https://connect.us.cray.com/jira/browse/PE-37951)


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
