### PR TITLE
CASMPET-5036: Update image refs in Helm charts

### DIFF
--- a/.github/workflows/charts-lint-test-scan-cron.yml
+++ b/.github/workflows/charts-lint-test-scan-cron.yml
@@ -1,0 +1,17 @@
+name: Cron Lint, test, and scan Helm charts
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+jobs:
+  lint-test-scan:
+    uses: Cray-HPE/.github/.github/workflows/charts-lint-test-scan.yml@main
+    with:
+      ct-config: |
+        chart-dirs:
+          - kubernetes
+        validate-maintainers: false
+      scan-chart-snyk-args: "--severity-threshold=high --policy-path=kubernetes/.snyk"
+      scan-image-snyk-args: "--severity-threshold=high"
+    secrets:
+      snyk-token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/charts-lint-test-scan.yml
+++ b/.github/workflows/charts-lint-test-scan.yml
@@ -1,0 +1,21 @@
+name: Lint, test, and scan Helm charts
+on:
+  pull_request:
+    branches:
+      - master
+      - release/**
+  workflow_dispatch:
+jobs:
+  lint-test-scan:
+    uses: Cray-HPE/.github/.github/workflows/charts-lint-test-scan.yml@main
+    with:
+      scan-image-snyk-args: "--severity-threshold=high"
+      lint-charts: ${{ github.event_name == 'pull_request' }}
+      ct-config: |
+        chart-dirs:
+          - kubernetes
+        validate-maintainers: false
+      scan-chart-snyk-args: "--severity-threshold=high --policy-path=kubernetes/.snyk"
+      test-charts: false
+    secrets:
+      snyk-token: ${{ secrets.SNYK_TOKEN }}

--- a/kubernetes/.snyk
+++ b/kubernetes/.snyk
@@ -1,0 +1,5 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore: {}
+patch: {}

--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -1,6 +1,15 @@
-apiVersion: v1
-appVersion: 0.24.0
+apiVersion: v2
 name: cray-opa
+version: 1.5.0
 description: Cray Open Policy Agent
-home: "cloud/cray-charts"
-version: 1.4.0
+keywords:
+- opa
+home: https://github.com/Cray-HPE/cray-opa
+sources:
+- https://github.com/Cray-HPE/cray-opa
+maintainers:
+- name: kburns-hpe
+- name: brantk-hpe
+appVersion: 0.24.0
+annotations:
+  artifacthub.io/license: MIT

--- a/kubernetes/cray-opa/templates/deployment.yaml
+++ b/kubernetes/cray-opa/templates/deployment.yaml
@@ -22,8 +22,8 @@ spec:
         app.kubernetes.io/managed-by: {{ $.Release.Service }}
     spec:
       containers:
-      - image: {{ $.Values.image }}:{{ $.Values.imageTag }}
-        imagePullPolicy: {{ $.Values.imagePullPolicy }}
+      - image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
+        imagePullPolicy: {{ $.Values.image.pullPolicy }}
         name: opa-istio
         env:
           - name: POLICY_CONFIGMAP_VERSION
@@ -59,6 +59,10 @@ spec:
         ports:
         - name: http
           containerPort: {{ $.Values.opa.containerPort }}
+        securityContext:
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
       volumes:
       - configMap:
           name: istio-config-{{ $name }}

--- a/kubernetes/cray-opa/templates/envoyfilter.yaml
+++ b/kubernetes/cray-opa/templates/envoyfilter.yaml
@@ -8,7 +8,7 @@ The non-obvious adjustments are:
 * Set context to GATEWAY since this applies to the ingressgateway
 * Set the OPA request timeout to avoid failures
 * Removed the `with_request_body` section. Our policy doesn't need the request body and it causes requests to fail.
-*/ -}}
+*/}}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:

--- a/kubernetes/cray-opa/tests/opa/Dockerfile
+++ b/kubernetes/cray-opa/tests/opa/Dockerfile
@@ -12,7 +12,7 @@ RUN cd src/run_tests && go mod download
 RUN cd src/run_tests && go build .
 RUN ls src/run_tests
 
-FROM arti.dev.cray.com/third-party-docker-stable-local/openpolicyagent/opa:0.24.0-envoy-1
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
 
 COPY --from=builder /go/src/run_tests/run_tests .
 COPY tests/opa/certificate_authority.crt /jwtValidationFetchTls/certificate_authority.crt

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -1,7 +1,9 @@
 ---
-image: openpolicyagent/opa
-imageTag: 0.24.0-envoy-1  # When changing this, also update files/Dockerfile.
-imagePullPolicy: IfNotPresent
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa
+  tag: 0.24.0-envoy-1  # When changing this, also update tests/opa//Dockerfile.
+  pullPolicy: IfNotPresent
+
 priorityClassName: csm-high-priority-service
 
 ingresses:
@@ -31,9 +33,9 @@ opa:
   port: 9191
   containerPort: 9191
   loglevel: info
-  query: data.istio.authz.allow # this should never really change
+  query: data.istio.authz.allow  # this should never really change
   tls:
-    enabled: false # TODO once we have cert manager
+    enabled: false  # TODO once we have cert manager
     secret: ""
   strategy:
     rollingUpdate:
@@ -55,14 +57,14 @@ opa:
   # http.send requests default to 5s timeout. This was failing on a system so
   # increase this to 10s.
   httpTimeout: 10s
-  requireHeartbeatToken: False
+  requireHeartbeatToken: false
   xnamePolicy:
-    enabled: True
-    bos: True
-    cfs: True
-    ckdump: False
-    dvs: False
-    heartbeat: False
+    enabled: true
+    bos: true
+    cfs: true
+    ckdump: false
+    dvs: false
+    heartbeat: false
 
 # To overide the default policy in files/policy.rego follow the example below
 # NOTE: If the policy changes or is overriden, you MUST do a rolling restart of the


### PR DESCRIPTION
### Summary and Scope

Followed the objectives in CASM-2670. The only image in this
repository is opa. That was referenced from docker.io and is now
using the image that's build from the container-images repository.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? new feature

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? Y

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-5036

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

I deployed this to vshasta and then just made sure I could still make a simple request and it wasn't rejected with an auth error. Not much testing but it's just changing the image to the same image that was rebuilt, and the securityContext change would likely have caused it to not start if that didn't work since this image is just starting opa which is self-contained.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

Requires: None
