### PR TITLE
CASMPET-5187 Disable xname validation by default

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-opa
-version: 1.5.0
+version: 1.6.0
 description: Cray Open Policy Agent
 keywords:
 - opa

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -59,9 +59,9 @@ opa:
   httpTimeout: 10s
   requireHeartbeatToken: false
   xnamePolicy:
-    enabled: true
-    bos: true
-    cfs: true
+    enabled: false
+    bos: false
+    cfs: false
     ckdump: false
     dvs: false
     heartbeat: false


### PR DESCRIPTION
## Summary and Scope

This disabled the xname validation by default. We won't be enabling them by default until we're sure it will work without a performance hit. The version is being bumped as this will be released as soon as it's merged.

## Issues and Related PRs

* Resolves [CASMPET-5187](https://connect.us.cray.com/jira/browse/CASMINST-5187)

## Testing

The enable/disable was tested when the option was added and a retest to disable the functionality is not needed.


## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

