### PR TITLE
CASMINST-4007 Update anti affinity support.

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,16 +23,16 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.8.1
+version: 1.9.0
 description: Cray Open Policy Agent
 keywords:
-  - opa
+- opa
 home: https://github.com/Cray-HPE/cray-opa
 sources:
-  - https://github.com/Cray-HPE/cray-opa
+- https://github.com/Cray-HPE/cray-opa
 maintainers:
-  - name: kburns-hpe
-  - name: brantk-hpe
+- name: kburns-hpe
+- name: brantk-hpe
 appVersion: 0.24.0
 annotations:
   artifacthub.io/license: MIT

--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,16 +23,16 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.8.0
+version: 1.8.1
 description: Cray Open Policy Agent
 keywords:
-- opa
+  - opa
 home: https://github.com/Cray-HPE/cray-opa
 sources:
-- https://github.com/Cray-HPE/cray-opa
+  - https://github.com/Cray-HPE/cray-opa
 maintainers:
-- name: kburns-hpe
-- name: brantk-hpe
+  - name: kburns-hpe
+  - name: brantk-hpe
 appVersion: 0.24.0
 annotations:
   artifacthub.io/license: MIT

--- a/kubernetes/cray-opa/templates/deployment.yaml
+++ b/kubernetes/cray-opa/templates/deployment.yaml
@@ -112,7 +112,7 @@ spec:
                  - key: app.kubernetes.io/name
                    operator: In
                    values:
-                   - {{ $name }}
+                   - cray-opa-{{ $name }}
                topologyKey: kubernetes.io/hostname
       {{- end }}
       {{ if $options.affinity }}

--- a/kubernetes/cray-opa/templates/deployment.yaml
+++ b/kubernetes/cray-opa/templates/deployment.yaml
@@ -102,12 +102,23 @@ spec:
           name: cray-configmap-ca-public-key
         name: fetch-jwt-certs-ca-vol
       affinity:
-      {{ if $.Values.affinity.default }}
+      {{- if eq $.Values.affinity.default "preferred" }}
         podAntiAffinity:
            preferredDuringSchedulingIgnoredDuringExecution:
            - weight: 1
              podAffinityTerm:
                labelSelector:
+                 matchExpressions:
+                 - key: app.kubernetes.io/name
+                   operator: In
+                   values:
+                   - cray-opa-{{ $name }}
+               topologyKey: kubernetes.io/hostname
+      {{- end }}
+      {{- if eq $.Values.affinity.default "required" }}
+        podAntiAffinity:
+           requiredDuringSchedulingIgnoredDuringExecution:
+             - labelSelector:
                  matchExpressions:
                  - key: app.kubernetes.io/name
                    operator: In

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -89,8 +89,8 @@ opa:
     dvs: false
     heartbeat: false
 
-# To overide the default policy in files/policy.rego follow the example below
-# NOTE: If the policy changes or is overriden, you MUST do a rolling restart of the
+# To override the default policy in files/policy.rego follow the example below
+# NOTE: If the policy changes or is overridden, you MUST do a rolling restart of the
 # OPA pods to pick them up until we stop mounting as a configmap.
 
 # policy: |
@@ -101,7 +101,9 @@ opa:
 
 # Run each opa pod on a separate worker when possible
 affinity:
-  default: true
+  # set default to 'preferred' for default preferred anti affinity rule
+  # set default to 'required' for default required anti affinity rule
+  default: required
 
 jwtValidation:
   keycloak:


### PR DESCRIPTION
## Summary and Scope

This change allows us to choose whether to use required or preferred anti affinity. Preferred is needed on vshasta. On systems with 4 or more worker nodes, required should be used.

## Issues and Related PRs

* Resolves [CASMINST-4007](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4007) 

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated anti affinity rules worked with both toggles and that they functioned correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? Y
- Was upgrade tested? Y
- Was downgrade tested? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

