### PR TITLE
CASMINST-3979 Disable external spire-jwks access

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,16 +23,16 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.9.0
+version: 1.10.0
 description: Cray Open Policy Agent
 keywords:
-- opa
+  - opa
 home: https://github.com/Cray-HPE/cray-opa
 sources:
-- https://github.com/Cray-HPE/cray-opa
+  - https://github.com/Cray-HPE/cray-opa
 maintainers:
-- name: kburns-hpe
-- name: brantk-hpe
+  - name: kburns-hpe
+  - name: brantk-hpe
 appVersion: 0.24.0
 annotations:
   artifacthub.io/license: MIT

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -58,7 +58,6 @@ allow {
     any([
         startswith(original_path, "/keycloak"),
         startswith(original_path, "/vcs"),
-        startswith(original_path, "/spire-jwks-"),
     ])
 }
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
@@ -16,8 +16,6 @@ test_allow_bypassed_urls_with_no_auth_header {
 
 test_deny_tokens_api {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/apis/tokens"}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-token/"}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-test/"}}}}
 }
 
 test_deny_apis_with_no_auth_header {
@@ -272,4 +270,3 @@ test_nexus {
   # Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "nexus_mock_path", "headers": {"x-envoy-decorator-operation": "invalid"}}}}}
 }
-

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
@@ -16,8 +16,6 @@ test_allow_bypassed_urls_with_no_auth_header {
 
 test_deny_tokens_api {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/apis/tokens"}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-token/"}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-test/"}}}}
 }
 
 test_deny_apis_with_no_auth_header {

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
@@ -16,8 +16,6 @@ test_allow_bypassed_urls_with_no_auth_header {
 
 test_deny_tokens_api {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/apis/tokens"}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-token/"}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-test/"}}}}
 }
 
 test_deny_apis_with_no_auth_header {

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
@@ -16,8 +16,6 @@ test_allow_bypassed_urls_with_no_auth_header {
 
 test_deny_tokens_api {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/apis/tokens"}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-token/"}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-test/"}}}}
 }
 
 test_deny_apis_with_no_auth_header {

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
@@ -12,8 +12,6 @@ test_allow_bypassed_urls_with_no_auth_header {
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/capsules/"}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-token/"}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-test/"}}}}
 }
 
 test_deny_tokens_endpoint {

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
@@ -12,8 +12,6 @@ test_allow_bypassed_urls_with_no_auth_header {
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/capsules/"}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-token/"}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-test/"}}}}
 }
 
 test_deny_tokens_api {

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
@@ -12,8 +12,6 @@ test_allow_bypassed_urls_with_no_auth_header {
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/capsules/"}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-token/"}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-test/"}}}}
 }
 
 test_deny_tokens_endpoint {

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -109,7 +109,7 @@ jwtValidation:
   keycloak:
     jwksUri: "https://istio-ingressgateway.istio-system.svc.cluster.local./keycloak/realms/shasta/protocol/openid-connect/certs"
   spire:
-    jwksUri: "https://istio-ingressgateway.istio-system.svc.cluster.local./spire-jwks-vshastaio/keys"
+    jwksUri: "http://spire-jwks.spire.svc.cluster.local/keys"
     issuers:
       vshasta.io: "http://spire.local/shasta/vshastaio"
     trustDomain: shasta


### PR DESCRIPTION
## Summary and Scope

Disabled exposing spire-jwks externally and switched the jwks endpoint opa uses to the internal URL.

## Issues and Related PRs

* Resolves [CASMINST-3979](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3979) 

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated that spire tokens kept working after the upgrade and failed if the spire-jwks service was scaled down to 0.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

If cray-opa gets downgraded to 1.9.0, spire also needs to be downgraded to 2.3.1 in order to create the spire-jwks VirtualService.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

