### PR TITLE
Casmhms 4961

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.10.1
+version: 1.10.2
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -253,7 +253,8 @@ allowed_methods := {
     #SMD -> GET everything, DVS needs SoftwareStatus.  REVOKED permission to update BulkSoftwareStatus
     {"method": "GET",  "path": `^/apis/smd/hsm/v./.*$`},
     {"method": "HEAD",  "path": `^/apis/smd/hsm/v./.*$`},
-    {"method": "PATCH", "path": sprintf("^/apis/smd/hsm/v./State/Components/%v/SoftwareStatus$", [parsed_spire_token.xname])},
+    #very naieve xname regex: [a-zA-Z0-9]* #make sure someone cant redirect the path with a /
+    {"method": "PATCH",  "path": `^/apis/smd/hsm/v./State/Components/[a-zA-Z0-9]*/SoftwareStatus$`},
 
     #HMNFD -> subscribe only, cannot create state change notifications
     {"method": "GET",  "path": `^/apis/hmnfd/hmi/v1/subscriptions$`},

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -250,10 +250,11 @@ allowed_methods := {
 
     {"method": "PUT",  "path": `^/apis/v2/nmd/status/.*$`},
 
-    #SMD -> GET everything, DVS currently needs to update BulkSoftwareStatus
+    #SMD -> GET everything, DVS needs SoftwareStatus.  REVOKED permission to update BulkSoftwareStatus
     {"method": "GET",  "path": `^/apis/smd/hsm/v./.*$`},
     {"method": "HEAD",  "path": `^/apis/smd/hsm/v./.*$`},
-    {"method": "PATCH",  "path": `^/apis/smd/hsm/v./State/Components/BulkSoftwareStatus$`},
+    {"method": "PATCH", "path": sprintf("^/apis/smd/hsm/v./State/Components/%v/SoftwareStatus$", [parsed_spire_token.xname])},
+
     #HMNFD -> subscribe only, cannot create state change notifications
     {"method": "GET",  "path": `^/apis/hmnfd/hmi/v1/subscriptions$`},
     {"method": "HEAD",  "path": `^/apis/hmnfd/hmi/v1/subscriptions$`},
@@ -371,10 +372,9 @@ spire_methods := {
     # These pass xnames via POST. This will be removed once the v2 API is being used.
     {"method": "POST", "path": `^/apis/hmnfd/hmi/v1/subscribe$`},
 
-    #SMD -> GET everything, DVS currently needs to update BulkSoftwareStatus
+    #SMD -> GET everything,  DVS needs SoftwareStatus.  REVOKED permission to update BulkSoftwareStatus
     {"method": "GET",   "path": `^/apis/smd/hsm/v./.*$`},
     {"method": "HEAD",  "path": `^/apis/smd/hsm/v./.*$`},
-    {"method": "PATCH", "path": `^/apis/smd/hsm/v./State/Components/BulkSoftwareStatus$`},
     {"method": "PATCH", "path": sprintf("^/apis/smd/hsm/v./State/Components/%v/SoftwareStatus$", [parsed_spire_token.xname])},
 
     #HMNFD -> subscribe only, cannot create state change notifications

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
@@ -104,6 +104,7 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
@@ -104,7 +104,6 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
@@ -108,7 +108,6 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
@@ -108,6 +108,7 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
@@ -108,7 +108,7 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"authorization": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
@@ -103,7 +103,6 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
@@ -103,6 +103,7 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
@@ -107,7 +107,6 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
@@ -107,7 +107,7 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"authorization": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
 
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
@@ -107,6 +107,8 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"authorization": compute_auth}}}}}
+
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
@@ -106,8 +106,7 @@ test_compute {
   # SMD - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"authorization": compute_auth}}}}}
-
+     
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
@@ -115,7 +115,6 @@ test_compute {
   # SMD - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"authorization": compute_auth}}}}}
 
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
@@ -226,6 +226,10 @@ spire_correct_ncn_sub(sub) {
 
   # Validate that only CFS can access
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": cfs_ncn_mock_path, "headers": {"authorization": sub}}}}}
+
+  #validate that DVS can access SoftwareStatus
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/ncnw001/SoftwareStatus", "headers": {"authorization": sub}}}}}
+
 }
 
 
@@ -259,6 +263,10 @@ spire_correct_compute_sub(sub) {
 
   # Validate that only CFS can access
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": cfs_compute_mock_path, "headers": {"authorization": sub}}}}}
+
+  #validate that DVS can access SoftwareStatus
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"authorization": sub}}}}}
+
 }
 
 spire_incorrect_xname_sub(sub) {

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
@@ -111,6 +111,8 @@ test_compute {
   # SMD - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"authorization": compute_auth}}}}}
+
 
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
@@ -111,7 +111,7 @@ test_compute {
   # SMD - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"authorization": compute_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
 
 
   # SMD - not allowed

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
@@ -111,7 +111,6 @@ test_compute {
   # SMD - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
 
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}


### PR DESCRIPTION
## Summary and Scope
remove the BulkSoftwareStatus path that was relied on by DVS.
Should go with CSM 1.2.6

## Issues and Related PRs


* Resolves CASMHMS-4961

## Testing


### Tested on:

  * build system

### Test description:
Ran `make`; builds passed.

## Risks and Mitigations



## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

