### PR TITLE
Casmhms 4961 master

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.13.1
+version: 1.14.0
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.13.0
+version: 1.13.1
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-admin.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-admin.tpl
@@ -183,8 +183,8 @@ allowed_methods := {
       {"method": "PATCH", "path": `^/apis/bos/.*$`},
       {"method": "DELETE", "path": `^/apis/bos/.*$`},
       # SMD - hardware state query
-      {"method": "GET",  "path": `^/apis/smd/hsm/v./.*$`},
-      {"method": "HEAD",  "path": `^/apis/smd/hsm/v./.*$`},
+      {"method": "GET",  "path": `^/apis/smd/hsm/v2/.*$`},
+      {"method": "HEAD",  "path": `^/apis/smd/hsm/v2/.*$`},
       # FC - VNI reservation
       {"method": "GET", "path": `^/apis/fc/.*$`},
       {"method": "HEAD", "path": `^/apis/fc/.*$`},

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
@@ -184,8 +184,8 @@ allowed_methods := {
       {"method": "PATCH", "path": `^/apis/bos/.*$`},
       {"method": "DELETE", "path": `^/apis/bos/.*$`},
       # SMD - hardware state query
-      {"method": "GET",  "path": `^/apis/smd/hsm/v./.*$`},
-      {"method": "HEAD",  "path": `^/apis/smd/hsm/v./.*$`},
+      {"method": "GET",  "path": `^/apis/smd/hsm/v2/.*$`},
+      {"method": "HEAD",  "path": `^/apis/smd/hsm/v2/.*$`},
       # FC - VNI reservation
       {"method": "GET", "path": `^/apis/fc/.*$`},
       {"method": "HEAD", "path": `^/apis/fc/.*$`},

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -250,10 +250,11 @@ allowed_methods := {
 
     {"method": "PUT",  "path": `^/apis/v2/nmd/status/.*$`},
 
-    #SMD -> GET everything, DVS currently needs to update BulkSoftwareStatus
+    #SMD -> GET everything, DVS needs SoftwareStatus.  REVOKED permission to update BulkSoftwareStatus
     {"method": "GET",  "path": `^/apis/smd/hsm/v./.*$`},
     {"method": "HEAD",  "path": `^/apis/smd/hsm/v./.*$`},
-    {"method": "PATCH",  "path": `^/apis/smd/hsm/v./State/Components/BulkSoftwareStatus$`},
+    #very naieve xname regex: [a-zA-Z0-9]* #make sure someone cant redirect the path with a /
+    {"method": "PATCH",  "path": `^/apis/smd/hsm/v./State/Components/[a-zA-Z0-9]*/SoftwareStatus$`},
     #HMNFD -> subscribe only, cannot create state change notifications
     {"method": "GET",  "path": `^/apis/hmnfd/hmi/v1/subscriptions$`},
     {"method": "HEAD",  "path": `^/apis/hmnfd/hmi/v1/subscriptions$`},
@@ -371,10 +372,9 @@ spire_methods := {
     # These pass xnames via POST. This will be removed once the v2 API is being used.
     {"method": "POST", "path": `^/apis/hmnfd/hmi/v1/subscribe$`},
 
-    #SMD -> GET everything, DVS currently needs to update BulkSoftwareStatus
+    #SMD -> GET everything,  DVS needs SoftwareStatus.  REVOKED permission to update BulkSoftwareStatus
     {"method": "GET",   "path": `^/apis/smd/hsm/v./.*$`},
     {"method": "HEAD",  "path": `^/apis/smd/hsm/v./.*$`},
-    {"method": "PATCH", "path": `^/apis/smd/hsm/v./State/Components/BulkSoftwareStatus$`},
     {"method": "PATCH", "path": sprintf("^/apis/smd/hsm/v./State/Components/%v/SoftwareStatus$", [parsed_spire_token.xname])},
 
     #HMNFD -> subscribe only, cannot create state change notifications

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -251,10 +251,10 @@ allowed_methods := {
     {"method": "PUT",  "path": `^/apis/v2/nmd/status/.*$`},
 
     #SMD -> GET everything, DVS needs SoftwareStatus.  REVOKED permission to update BulkSoftwareStatus
-    {"method": "GET",  "path": `^/apis/smd/hsm/v./.*$`},
-    {"method": "HEAD",  "path": `^/apis/smd/hsm/v./.*$`},
+    {"method": "GET",  "path": `^/apis/smd/hsm/v2/.*$`},
+    {"method": "HEAD",  "path": `^/apis/smd/hsm/v2/.*$`},
     #very naieve xname regex: [a-zA-Z0-9]* #make sure someone cant redirect the path with a /
-    {"method": "PATCH",  "path": `^/apis/smd/hsm/v./State/Components/[a-zA-Z0-9]*/SoftwareStatus$`},
+    {"method": "PATCH",  "path": `^/apis/smd/hsm/v2/State/Components/[a-zA-Z0-9]*/SoftwareStatus$`},
     #HMNFD -> subscribe only, cannot create state change notifications
     {"method": "GET",  "path": `^/apis/hmnfd/hmi/v1/subscriptions$`},
     {"method": "HEAD",  "path": `^/apis/hmnfd/hmi/v1/subscriptions$`},
@@ -295,8 +295,8 @@ allowed_methods := {
       {"method": "PATCH", "path": `^/apis/bos/.*$`},
       {"method": "DELETE", "path": `^/apis/bos/.*$`},
       # SMD - hardware state query
-      {"method": "GET",  "path": `^/apis/smd/hsm/v./.*$`},
-      {"method": "HEAD",  "path": `^/apis/smd/hsm/v./.*$`},
+      {"method": "GET",  "path": `^/apis/smd/hsm/v2/.*$`},
+      {"method": "HEAD",  "path": `^/apis/smd/hsm/v2/.*$`},
       # FC - VNI reservation
       {"method": "GET", "path": `^/apis/fc/.*$`},
       {"method": "HEAD", "path": `^/apis/fc/.*$`},
@@ -373,9 +373,9 @@ spire_methods := {
     {"method": "POST", "path": `^/apis/hmnfd/hmi/v1/subscribe$`},
 
     #SMD -> GET everything,  DVS needs SoftwareStatus.  REVOKED permission to update BulkSoftwareStatus
-    {"method": "GET",   "path": `^/apis/smd/hsm/v./.*$`},
-    {"method": "HEAD",  "path": `^/apis/smd/hsm/v./.*$`},
-    {"method": "PATCH", "path": sprintf("^/apis/smd/hsm/v./State/Components/%v/SoftwareStatus$", [parsed_spire_token.xname])},
+    {"method": "GET",   "path": `^/apis/smd/hsm/v2/.*$`},
+    {"method": "HEAD",  "path": `^/apis/smd/hsm/v2/.*$`},
+    {"method": "PATCH", "path": sprintf("^/apis/smd/hsm/v2/State/Components/%v/SoftwareStatus$", [parsed_spire_token.xname])},
 
     #HMNFD -> subscribe only, cannot create state change notifications
     {"method": "GET",   "path": `^/apis/hmnfd/hmi/v1/subscriptions$`},
@@ -415,8 +415,8 @@ spire_methods := {
       {"method": "PATCH", "path": `^/apis/bos/.*$`},
       {"method": "DELETE", "path": `^/apis/bos/.*$`},
       # SMD - hardware state query
-      {"method": "GET",  "path": `^/apis/smd/hsm/v./.*$`},
-      {"method": "HEAD",  "path": `^/apis/smd/hsm/v./.*$`},
+      {"method": "GET",  "path": `^/apis/smd/hsm/v2/.*$`},
+      {"method": "HEAD",  "path": `^/apis/smd/hsm/v2/.*$`},
       # FC - VNI reservation
       {"method": "GET", "path": `^/apis/fc/.*$`},
       {"method": "HEAD", "path": `^/apis/fc/.*$`},

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
@@ -104,7 +104,7 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"authorization": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
@@ -104,7 +104,7 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"authorization": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v2/State/Components/x1/SoftwareStatus", "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
@@ -108,7 +108,7 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
@@ -108,7 +108,7 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v2/State/Components/x1/SoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
@@ -103,7 +103,7 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"authorization": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
@@ -103,7 +103,7 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"authorization": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v2/State/Components/x1/SoftwareStatus", "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
@@ -107,7 +107,7 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v2/State/Components/x1/SoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
@@ -107,7 +107,7 @@ test_deny_compute {
   # SMD - Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
@@ -106,7 +106,6 @@ test_compute {
   # SMD - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"authorization": compute_auth}}}}}
 
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
@@ -115,7 +115,6 @@ test_compute {
   # SMD - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"authorization": compute_auth}}}}}
 
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
@@ -227,6 +226,10 @@ spire_correct_ncn_sub(sub) {
 
   # Validate that only CFS can access
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": cfs_ncn_mock_path, "headers": {"authorization": sub}}}}}
+
+  #validate that DVS can access SoftwareStatus
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/ncnw001/SoftwareStatus", "headers": {"authorization": sub}}}}}
+
 }
 
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
@@ -65,9 +65,9 @@ cps_mock_path = "/apis/v2/cps/mock"
 hbtb_heartbeat_path = "/apis/hbtd/hmi/v1/heartbeat"
 nmd_mock_path = "/apis/v2/nmd/status"
 smd_statecomponents_path = "/apis/smd/hsm/v2/State/Components"
-smd_softwarestatus_compute_path = "/apis/smd/hsm/v./State/Components/x1/SoftwareStatus"
-smd_softwarestatus_ncn_path = "/apis/smd/hsm/v./State/Components/ncnw001/SoftwareStatus"
-smd_softwarestatus_invalid_path = "/apis/smd/hsm/v./State/Components/invalid/SoftwareStatus"
+smd_softwarestatus_compute_path = "/apis/smd/hsm/v2/State/Components/x1/SoftwareStatus"
+smd_softwarestatus_ncn_path = "/apis/smd/hsm/v2/State/Components/ncnw001/SoftwareStatus"
+smd_softwarestatus_invalid_path = "/apis/smd/hsm/v2/State/Components/invalid/SoftwareStatus"
 hmnfd_subscribe_path = "/apis/hmnfd/hmi/v1/subscribe"
 hmnfd_subscriptions_path = "/apis/hmnfd/hmi/v1/subscriptions"
 pals_mock_path = "/apis/pals/v1/mock"
@@ -228,7 +228,7 @@ spire_correct_ncn_sub(sub) {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": cfs_ncn_mock_path, "headers": {"authorization": sub}}}}}
 
   #validate that DVS can access SoftwareStatus
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/ncnw001/SoftwareStatus", "headers": {"authorization": sub}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v2/State/Components/ncnw001/SoftwareStatus", "headers": {"authorization": sub}}}}}
 
 }
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
@@ -111,7 +111,7 @@ test_compute {
   # SMD - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v2/State/Components/x1/SoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
 
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
@@ -111,7 +111,7 @@ test_compute {
   # SMD - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/x1/SoftwareStatus", "headers": {"x-forwarded-access-token": compute_auth}}}}}
 
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": compute_auth}}}}}


### PR DESCRIPTION
## Summary and Scope
remove the BulkSoftwareStatus path that was relied on by DVS.
Should go with CSM 1.2.6

## Issues and Related PRs


* Resolves CASMHMS-4961

## Testing


### Tested on:

  * build system

### Test description:
Ran `make`; builds passed.

## Risks and Mitigations



## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

