### PR TITLE
CASMINST-4757 Add required pod antiaffinity

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.10.2
+version: 1.10.3
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.10.3
+version: 1.10.10
 description: Cray Open Policy Agent
 keywords:
   - opa
@@ -32,7 +32,6 @@ sources:
   - https://github.com/Cray-HPE/cray-opa
 maintainers:
   - name: kburns-hpe
-  - name: brantk-hpe
 appVersion: 0.24.0
 annotations:
   artifacthub.io/license: MIT

--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.10.1
+version: 1.10.2
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/deployment.yaml
+++ b/kubernetes/cray-opa/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         env:
           - name: POLICY_CONFIGMAP_VERSION
             # Change to force opa pods to restart and re-read ConfigMap.
-            value: "8"
+            value: "9"
           {{- if $.Values.opa.httpTimeout }}
           - name: HTTP_SEND_TIMEOUT
             value: {{ $.Values.opa.httpTimeout | quote }}

--- a/kubernetes/cray-opa/templates/deployment.yaml
+++ b/kubernetes/cray-opa/templates/deployment.yaml
@@ -22,6 +22,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 */}}
 {{- range $name, $options:= .Values.ingresses }}
+{{ $uuid := uuidv4 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -43,6 +44,7 @@ spec:
         app.kubernetes.io/name: cray-opa-{{ $name }}
         app.kubernetes.io/instance: {{ $.Release.Name }}
         app.kubernetes.io/managed-by: {{ $.Release.Service }}
+        deployment/uuid: {{ $uuid }}
     spec:
       containers:
       - image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
@@ -51,7 +53,7 @@ spec:
         env:
           - name: POLICY_CONFIGMAP_VERSION
             # Change to force opa pods to restart and re-read ConfigMap.
-            value: "9"
+            value: "10"
           {{- if $.Values.opa.httpTimeout }}
           - name: HTTP_SEND_TIMEOUT
             value: {{ $.Values.opa.httpTimeout | quote }}
@@ -114,16 +116,21 @@ spec:
                    values:
                    - cray-opa-{{ $name }}
                topologyKey: kubernetes.io/hostname
+              topologyKey: kubernetes.io/hostname
       {{- end }}
       {{- if eq $.Values.affinity.default "required" }}
         podAntiAffinity:
            requiredDuringSchedulingIgnoredDuringExecution:
              - labelSelector:
-                 matchExpressions:
-                 - key: app.kubernetes.io/name
-                   operator: In
-                   values:
-                   - cray-opa-{{ $name }}
+                matchExpressions:
+                - key: deployment/uuid
+                  operator: In
+                  values:
+                  - {{ $uuid }}
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - cray-opa-{{ $name }}
                topologyKey: kubernetes.io/hostname
       {{- end }}
       {{ if $options.affinity }}

--- a/kubernetes/cray-opa/templates/deployment.yaml
+++ b/kubernetes/cray-opa/templates/deployment.yaml
@@ -127,10 +127,6 @@ spec:
                   operator: In
                   values:
                   - {{ $uuid }}
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - cray-opa-{{ $name }}
                topologyKey: kubernetes.io/hostname
       {{- end }}
       {{ if $options.affinity }}

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -24,7 +24,7 @@
 ---
 image:
   repository: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa
-  tag: 0.24.0-envoy-1  # When changing this, also update tests/opa//Dockerfile.
+  tag: 0.24.0-envoy-1 # When changing this, also update tests/opa//Dockerfile.
   pullPolicy: IfNotPresent
 
 priorityClassName: csm-high-priority-service
@@ -56,9 +56,9 @@ opa:
   port: 9191
   containerPort: 9191
   loglevel: info
-  query: data.istio.authz.allow  # this should never really change
+  query: data.istio.authz.allow # this should never really change
   tls:
-    enabled: false  # TODO once we have cert manager
+    enabled: false # TODO once we have cert manager
     secret: ""
   strategy:
     rollingUpdate:
@@ -103,7 +103,7 @@ opa:
 affinity:
   # set default to 'preferred' for default preferred anti affinity rule
   # set default to 'required' for default required anti affinity rule
-  default: required
+  default: preferred
 
 jwtValidation:
   keycloak:

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -24,7 +24,7 @@
 ---
 image:
   repository: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa
-  tag: 0.24.0-envoy-1 # When changing this, also update tests/opa//Dockerfile.
+  tag: 0.24.0-envoy-1  # When changing this, also update tests/opa//Dockerfile.
   pullPolicy: IfNotPresent
 
 priorityClassName: csm-high-priority-service
@@ -56,9 +56,9 @@ opa:
   port: 9191
   containerPort: 9191
   loglevel: info
-  query: data.istio.authz.allow # this should never really change
+  query: data.istio.authz.allow  # this should never really change
   tls:
-    enabled: false # TODO once we have cert manager
+    enabled: false  # TODO once we have cert manager
     secret: ""
   strategy:
     rollingUpdate:
@@ -103,7 +103,7 @@ opa:
 affinity:
   # set default to 'preferred' for default preferred anti affinity rule
   # set default to 'required' for default required anti affinity rule
-  default: preferred
+  default: required
 
 jwtValidation:
   keycloak:


### PR DESCRIPTION
## Summary and Scope

Adds UUID and pod disruption policies to allow us to use requiredDuringSchedulingIgnoredDuringExecution pod anti affinity policies without causing upgrade issues on clusters with 3 workers.

## Issues and Related PRs


* Resolves [CASMINST-4757](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4757)

## Testing


### Tested on:

  * Virtual Shasta

### Test description:

Validated that upgrades worked on a 3 worker node cluster and that changing the replicas to 4 caused the 4th replicas to get stuck in pending due to requiredDuringSchedulingIgnoredDuringExecution.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?  N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

