### PR TITLE
CASMINST-4757 Add required pod antiaffinity

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.14.0
+version: 1.15.0
 description: Cray Open Policy Agent
 keywords:
   - opa
@@ -31,8 +31,8 @@ home: https://github.com/Cray-HPE/cray-opa
 sources:
   - https://github.com/Cray-HPE/cray-opa
 maintainers:
-- name: kburns-hpe
-- name: brantk-hpe
+  - name: kburns-hpe
+  - name: brantk-hpe
 appVersion: 0.26.0
 annotations:
   artifacthub.io/license: MIT

--- a/kubernetes/cray-opa/templates/deployment.yaml
+++ b/kubernetes/cray-opa/templates/deployment.yaml
@@ -22,6 +22,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 */}}
 {{- range $name, $options:= .Values.ingresses }}
+{{ $uuid := uuidv4 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -43,6 +44,7 @@ spec:
         app.kubernetes.io/name: cray-opa-{{ $name }}
         app.kubernetes.io/instance: {{ $.Release.Name }}
         app.kubernetes.io/managed-by: {{ $.Release.Service }}
+        deployment/uuid: {{ $uuid }}
     spec:
       containers:
       - image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
@@ -120,6 +122,10 @@ spec:
            requiredDuringSchedulingIgnoredDuringExecution:
              - labelSelector:
                  matchExpressions:
+                 - key: deployment/uuid
+                   operator: In
+                   values:
+                   - {{ $uuid }}
                  - key: app.kubernetes.io/name
                    operator: In
                    values:

--- a/kubernetes/cray-opa/templates/deployment.yaml
+++ b/kubernetes/cray-opa/templates/deployment.yaml
@@ -126,10 +126,6 @@ spec:
                    operator: In
                    values:
                    - {{ $uuid }}
-                 - key: app.kubernetes.io/name
-                   operator: In
-                   values:
-                   - cray-opa-{{ $name }}
                topologyKey: kubernetes.io/hostname
       {{- end }}
       {{ if $options.affinity }}


### PR DESCRIPTION
## Summary and Scope

Adds UUID and pod disruption policies to allow us to use requiredDuringSchedulingIgnoredDuringExecution pod anti affinity policies without causing upgrade issues on clusters with 3 workers.

## Issues and Related PRs


* Resolves [CASMINST-4757](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4757)

## Testing


### Tested on:

  * Virtual Shasta

### Test description:

Validated that upgrades worked on a 3 worker node cluster and that changing the replicas to 4 caused the 4th replicas to get stuck in pending due to requiredDuringSchedulingIgnoredDuringExecution.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?  N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

