### PR TITLE
CASMPET-5664: Add rules for read-only monitoring role

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.11.0
+version: 1.11.1
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-admin.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-admin.tpl
@@ -37,6 +37,21 @@ allow {
     http_request.headers["x-envoy-decorator-operation"] = "nexus.nexus.svc.cluster.local:80/*"
 }
 
+# Whitelist traffic to the Grafana web UI since it uses Keycloak for authentication.
+allow {
+    http_request.headers["x-envoy-decorator-operation"] = "cray-sysmgmt-health-grafana.sysmgmt-health.svc.cluster.local:80/*"
+}
+
+# Whitelist traffic to SMA Grafana web UI since it uses Keycloak for authentication.
+allow {
+    http_request.headers["x-envoy-decorator-operation"] = "sma-grafana.services.svc.cluster.local:3000/*"
+}
+
+# Whitelist traffic to SMA Kibana web UI since it uses Keycloak for authentication.
+allow {
+    http_request.headers["x-envoy-decorator-operation"] = "sma-kibana.services.svc.cluster.local:5601/*"
+}
+
 # The path being requested from the user. When the envoy filter is configured for
 # SIDECAR_INBOUND this is: http_request.headers["x-envoy-original-path"].
 # When configured for GATEWAY this is http_request.path
@@ -206,6 +221,10 @@ allowed_methods := {
       {"method": "POST",  "path": `^/apis/v2/nmd/.*$`},
       {"method": "PUT",  "path": `^/apis/v2/nmd/.*$`},
   ],
+  "monitor-ro": [
+      # SMA
+      {"method": "GET", "path": `^/apis/sma-telemetry-api/.*$`}, # All SMA telemetry API Calls - GET
+  ],
 }
 
 # Our list of endpoints we accept based on roles.
@@ -215,6 +234,7 @@ role_perms = {
     "wlm": allowed_methods["wlm"],
     "admin": allowed_methods["admin"],
     "ckdump": allowed_methods["ckdump"],
+    "monitor-ro": allowed_methods["monitor-ro"],
 }
 
 {{ end }}

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
@@ -37,6 +37,21 @@ allow {
     http_request.headers["x-envoy-decorator-operation"] = "nexus.nexus.svc.cluster.local:80/*"
 }
 
+# Whitelist traffic to the Grafana web UI since it uses Keycloak for authentication.
+allow {
+    http_request.headers["x-envoy-decorator-operation"] = "cray-sysmgmt-health-grafana.sysmgmt-health.svc.cluster.local:80/*"
+}
+
+# Whitelist traffic to SMA Grafana web UI since it uses Keycloak for authentication.
+allow {
+    http_request.headers["x-envoy-decorator-operation"] = "sma-grafana.services.svc.cluster.local:3000/*"
+}
+
+# Whitelist traffic to SMA Kibana web UI since it uses Keycloak for authentication.
+allow {
+    http_request.headers["x-envoy-decorator-operation"] = "sma-kibana.services.svc.cluster.local:5601/*"
+}
+
 # The path being requested from the user. When the envoy filter is configured for
 # SIDECAR_INBOUND this is: http_request.headers["x-envoy-original-path"].
 # When configured for GATEWAY this is http_request.path
@@ -199,6 +214,10 @@ allowed_methods := {
       {"method": "POST",  "path": `^/apis/v2/nmd/.*$`},
       {"method": "PUT",  "path": `^/apis/v2/nmd/.*$`},
   ],
+  "monitor-ro": [
+      # SMA
+      {"method": "GET", "path": `^/apis/sma-telemetry-api/.*$`}, # All SMA telemetry API Calls - GET
+  ],
 }
 
 # Our list of endpoints we accept based on roles.
@@ -206,6 +225,7 @@ role_perms = {
     "user": allowed_methods["user"],
     "wlm": allowed_methods["wlm"],
     "ckdump": allowed_methods["ckdump"],
+    "monitor-ro": allowed_methods["monitor-ro"],
 }
 
 

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -37,6 +37,21 @@ allow {
     http_request.headers["x-envoy-decorator-operation"] = "nexus.nexus.svc.cluster.local:80/*"
 }
 
+# Whitelist traffic to the Grafana web UI since it uses Keycloak for authentication.
+allow {
+    http_request.headers["x-envoy-decorator-operation"] = "cray-sysmgmt-health-grafana.sysmgmt-health.svc.cluster.local:80/*"
+}
+
+# Whitelist traffic to SMA Grafana web UI since it uses Keycloak for authentication.
+allow {
+    http_request.headers["x-envoy-decorator-operation"] = "sma-grafana.services.svc.cluster.local:3000/*"
+}
+
+# Whitelist traffic to SMA Kibana web UI since it uses Keycloak for authentication.
+allow {
+    http_request.headers["x-envoy-decorator-operation"] = "sma-kibana.services.svc.cluster.local:5601/*"
+}
+
 # The path being requested from the user. When the envoy filter is configured for
 # SIDECAR_INBOUND this is: http_request.headers["x-envoy-original-path"].
 # When configured for GATEWAY this is http_request.path
@@ -333,6 +348,10 @@ allowed_methods := {
   "ckdump": [
       {"method": "PUT",  "path": `^/apis/v2/nmd/status/.*$`},
   ],
+  "monitor-ro": [
+      # SMA
+      {"method": "GET", "path": `^/apis/sma-telemetry-api/.*$`}, # All SMA telemetry API Calls - GET
+  ],
 }
 
 # Our list of endpoints we accept based on roles.
@@ -343,6 +362,7 @@ role_perms = {
     "system-compute": allowed_methods["system-compute"],
     "wlm": allowed_methods["wlm"],
     "admin": allowed_methods["admin"],
+    "monitor-ro": allowed_methods["monitor-ro"],
 }
 
 {{- if .Values.opa.xnamePolicy.enabled }}

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
@@ -270,3 +270,18 @@ test_nexus {
   # Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "nexus_mock_path", "headers": {"x-envoy-decorator-operation": "invalid"}}}}}
 }
+
+test_grafana {
+  # Allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "grafana_mock_path", "headers": {"x-envoy-decorator-operation": "cray-sysmgmt-health-grafana.sysmgmt-health.svc.cluster.local:80/*"}}}}}
+}
+
+test_sma_grafana {
+  # Allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "sma_grafana_mock_path", "headers": {"x-envoy-decorator-operation": "sma-grafana.services.svc.cluster.local:3000/*"}}}}}
+}
+
+test_sma_kibana {
+  # Allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "sma_kibana_mock_path", "headers": {"x-envoy-decorator-operation": "sma-kibana.services.svc.cluster.local:5601/*"}}}}}
+}

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
@@ -269,3 +269,18 @@ test_nexus {
   # Not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "nexus_mock_path", "headers": {"x-envoy-decorator-operation": "invalid"}}}}}
 }
+
+test_grafana {
+  # Allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "grafana_mock_path", "headers": {"x-envoy-decorator-operation": "cray-sysmgmt-health-grafana.sysmgmt-health.svc.cluster.local:80/*"}}}}}
+}
+
+test_sma_grafana {
+  # Allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "sma_grafana_mock_path", "headers": {"x-envoy-decorator-operation": "sma-grafana.services.svc.cluster.local:3000/*"}}}}}
+}
+
+test_sma_kibana {
+  # Allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "sma_kibana_mock_path", "headers": {"x-envoy-decorator-operation": "sma-kibana.services.svc.cluster.local:5601/*"}}}}}
+}

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
@@ -285,6 +285,21 @@ test_nexus {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "nexus_mock_path", "headers": {"x-envoy-decorator-operation": "invalid"}}}}}
 }
 
+test_grafana {
+  # Allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "grafana_mock_path", "headers": {"x-envoy-decorator-operation": "cray-sysmgmt-health-grafana.sysmgmt-health.svc.cluster.local:80/*"}}}}}
+}
+
+test_sma_grafana {
+  # Allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "sma_grafana_mock_path", "headers": {"x-envoy-decorator-operation": "sma-grafana.services.svc.cluster.local:3000/*"}}}}}
+}
+
+test_sma_kibana {
+  # Allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "sma_kibana_mock_path", "headers": {"x-envoy-decorator-operation": "sma-kibana.services.svc.cluster.local:5601/*"}}}}}
+}
+
 test_argo_server{
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "argo_mock_path", "headers": {"x-forwarded-access-token": "{{ .adminToken }}", "x-envoy-decorator-operation": "cray-nls-argo-workflows-server.argo.svc.cluster.local:2746/*"}}}}}
 


### PR DESCRIPTION
## Summary and Scope

Add OPA rules for SMA telemetry API and monitoring app access for the read-only monitoring role.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5664](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5664)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

### Tested on:

  * `mug`
  * Virtual Shasta

### Test description:

Made sure that a user with read-only monitoring role can log into Grafana UI and have access to telemetry API.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

