### PR TITLE
CASMPET-5793 Update opa-envoy to 0.42.1

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.17.0
+version: 1.18.0
 description: Cray Open Policy Agent
 keywords:
   - opa
@@ -31,7 +31,10 @@ home: https://github.com/Cray-HPE/cray-opa
 sources:
   - https://github.com/Cray-HPE/cray-opa
 maintainers:
-- name: kburns-hpe
-appVersion: 0.26.0
+  - name: kburns-hpe
+appVersion: 0.42.0
 annotations:
+  artifacthub.io/images: |-
+    - name: cray-opa
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
   artifacthub.io/license: MIT

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
@@ -22,15 +22,24 @@ allow {
     # Limit scope to hmcollector to prevent unauthenticated access to other
     # management services.
     http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
-    any([
-        # HMN subnet (River)
-        net.cidr_contains("10.254.0.0/17", source_address.Address.SocketAddress.address),
-        # HMN subnet (Mountain)
-        net.cidr_contains("10.100.106.0/23", source_address.Address.SocketAddress.address),
-        # pod subnet
-        net.cidr_contains("10.32.0.0/12", source_address.Address.SocketAddress.address),
-    ])
+    # HMN subnet (River)
+    net.cidr_contains("10.254.0.0/17", source_address.Address.SocketAddress.address)
 }
+allow {
+    # Limit scope to hmcollector to prevent unauthenticated access to other
+    # management services.
+    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
+    # HMN subnet (Mountain)
+    net.cidr_contains("10.100.106.0/23", source_address.Address.SocketAddress.address)
+}
+allow {
+    # Limit scope to hmcollector to prevent unauthenticated access to other
+    # management services.
+    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
+    # pod subnet
+    net.cidr_contains("10.32.0.0/12", source_address.Address.SocketAddress.address)
+}
+
 
 # Whitelist traffic to the Neuxs web UI since it uses Keycloak for authentication.
 allow {
@@ -64,41 +73,25 @@ original_path = o_path {
 #
 #     * VCS/Gitea
 #
-allow {
-    any([
-        startswith(original_path, "/keycloak"),
-        startswith(original_path, "/vcs"),
-    ])
-}
+allow { startswith(original_path, "/keycloak") }
+allow { startswith(original_path, "/vcs") }
 
 # Allow cloud-init endpoints, as we do validation based on incoming IP.
 # In the future, these requests will come in via the TOR switches and ideally
 # not through the 'front door'.   This is an expansion to BSS.
-allow {
-    any([
-        startswith(original_path, "/meta-data"),
-        startswith(original_path, "/user-data"),
-        startswith(original_path, "/phone-home"),
-    ])
-}
+allow { startswith(original_path, "/meta-data") }
+allow { startswith(original_path, "/user-data") }
+allow { startswith(original_path, "/phone-home") }
 
 # Whitelist Nexus repository pods. Nexus uses it's own RBAC so open
 # all commands. Keycloak Gatekeeper is used to pass the tokens through
-allow {
-    any([
-        startswith(original_path, "/repository"),
-        startswith(original_path, "/v2"),
-        startswith(original_path, "/service/rest"),
-    ])
-}
+allow { startswith(original_path, "/repository") }
+allow { startswith(original_path, "/v2") }
+allow { startswith(original_path, "/service/rest") }
 
 # Whitelist Capsules UI. The Capsules UI starts at a login page which validates user access by retrieving a valid
 # token from keycloak with the provided credentials.
-allow {
-    any([
-        startswith(original_path, "/capsules/")
-    ])
-}
+allow { startswith(original_path, "/capsules/") }
 
 # This actually checks that the JWT token passed in
 # has access to the endpoint requested
@@ -123,7 +116,7 @@ found_auth = {"type": a_type, "token": a_token} {
 parsed_kc_token = {"payload": payload} {
     found_auth.type == "Bearer"
     response := http.send({"method": "get", "url": "{{ .Values.jwtValidation.keycloak.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt"})
-    [valid, header, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "shasta"})
+    [_, _, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "shasta"})
 
     # Verify that the issuer is as expected.
     allowed_issuers := [

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -22,14 +22,22 @@ allow {
     # Limit scope to hmcollector to prevent unauthenticated access to other
     # management services.
     http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
-    any([
-        # HMN subnet (River)
-        net.cidr_contains("10.254.0.0/17", source_address.Address.SocketAddress.address),
-        # HMN subnet (Mountain)
-        net.cidr_contains("10.100.106.0/23", source_address.Address.SocketAddress.address),
-        # pod subnet
-        net.cidr_contains("10.32.0.0/12", source_address.Address.SocketAddress.address),
-    ])
+    # HMN subnet (River)
+    net.cidr_contains("10.254.0.0/17", source_address.Address.SocketAddress.address)
+}
+allow {
+    # Limit scope to hmcollector to prevent unauthenticated access to other
+    # management services.
+    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
+    # HMN subnet (Mountain)
+    net.cidr_contains("10.100.106.0/23", source_address.Address.SocketAddress.address)
+}
+allow {
+    # Limit scope to hmcollector to prevent unauthenticated access to other
+    # management services.
+    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
+    # pod subnet
+    net.cidr_contains("10.32.0.0/12", source_address.Address.SocketAddress.address)
 }
 
 # Whitelist traffic to the Neuxs web UI since it uses Keycloak for authentication.
@@ -69,50 +77,29 @@ original_body = o_path {
 #
 #     * VCS/Gitea
 #
-allow {
-    any([
-        startswith(original_path, "/keycloak"),
-        startswith(original_path, "/vcs"),
-    ])
-}
-
+allow { startswith(original_path, "/keycloak") }
+allow { startswith(original_path, "/vcs") }
 # Allow cloud-init endpoints, as we do validation based on incoming IP.
 # In the future, these requests will come in via the TOR switches and ideally
 # not through the 'front door'.   This is an expansion to BSS.
-allow {
-    any([
-        startswith(original_path, "/meta-data"),
-        startswith(original_path, "/user-data"),
-        startswith(original_path, "/phone-home"),
-    ])
-}
+allow { startswith(original_path, "/meta-data") }
+allow { startswith(original_path, "/user-data") }
+allow { startswith(original_path, "/phone-home") }
 
 # Whitelist Nexus repository pods. Nexus uses it's own RBAC so open
 # all commands. Keycloak Gatekeeper is used to pass the tokens through
-allow {
-    any([
-        startswith(original_path, "/repository"),
-        startswith(original_path, "/v2"),
-        startswith(original_path, "/service/rest"),
-    ])
-}
+allow { startswith(original_path, "/repository") }
+allow { startswith(original_path, "/v2") }
+allow { startswith(original_path, "/service/rest") }
 
 # Whitelist Capsules UI. The Capsules UI starts at a login page which validates user access by retrieving a valid
 # token from keycloak with the provided credentials.
-allow {
-    any([
-        startswith(original_path, "/capsules/")
-    ])
-}
+allow { startswith(original_path, "/capsules/") }
 
 
 {{- if not .Values.opa.requireHeartbeatToken }}
 # Allow heartbeats without requiring a spire token
-allow {
-    any([
-        startswith(original_path, "/apis/hbtd/hmi/v1/heartbeat")
-    ])
-}
+allow { startswith(original_path, "/apis/hbtd/hmi/v1/heartbeat") }
 {{- end }}
 
 # This actually checks the JWT token passed in
@@ -174,7 +161,7 @@ found_auth = {"type": a_type, "token": a_token} {
 parsed_kc_token = {"payload": payload} {
     found_auth.type == "Bearer"
     response := http.send({"method": "get", "url": "{{ .Values.jwtValidation.keycloak.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt"})
-    [valid, header, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "shasta"})
+    [_, _, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "shasta"})
 
     # Verify that the issuer is as expected.
     allowed_issuers := [
@@ -190,7 +177,7 @@ parsed_kc_token = {"payload": payload} {
 parsed_spire_token = {"payload": payload, "xname": xname} {
     found_auth.type == "Bearer"
     response := http.send({"method": "get", "url": "{{ .Values.jwtValidation.spire.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt"})
-    [valid, header, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "system-compute"})
+    [_, _, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "system-compute"})
 
     # Verify that the issuer is as expected.
     allowed_issuers := [
@@ -207,7 +194,7 @@ parsed_spire_token = {"payload": payload, "xname": xname} {
 parsed_spire_token = {"payload": payload} {
     found_auth.type == "Bearer"
     response := http.send({"method": "get", "url": "{{ .Values.jwtValidation.spire.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt"})
-    [valid, header, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "system-compute"})
+    [_, _, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "system-compute"})
 
     # Verify that the issuer is as expected.
     allowed_issuers := [

--- a/kubernetes/cray-opa/tests/opa/Dockerfile
+++ b/kubernetes/cray-opa/tests/opa/Dockerfile
@@ -25,9 +25,9 @@
 FROM arti.dev.cray.com/baseos-docker-master-local/golang:1.14.9-alpine3.12 AS builder
 
 ENV GO111MODULE=on \
-    CGO_ENABLED=0 \
-    GOOS=linux \
-    GOARCH=amd64
+  CGO_ENABLED=0 \
+  GOOS=linux \
+  GOARCH=amd64
 
 COPY tests/opa/run_tests src/run_tests
 
@@ -35,7 +35,7 @@ RUN cd src/run_tests && go mod download
 RUN cd src/run_tests && go build .
 RUN ls src/run_tests
 
-FROM artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.26.0-envoy-6
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
 
 COPY --from=builder /go/src/run_tests/run_tests .
 COPY tests/opa/certificate_authority.crt /jwtValidationFetchTls/certificate_authority.crt

--- a/kubernetes/cray-opa/tests/opa/run_tests/run_tests.go
+++ b/kubernetes/cray-opa/tests/opa/run_tests/run_tests.go
@@ -124,7 +124,8 @@ func main() {
 	var spireSub string
 
 	args := createTokenArgs{
-		role: "admin", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer"}
+		role: "admin", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer",
+	}
 	adminToken, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -139,7 +140,8 @@ func main() {
 	fmt.Println("user token:", userToken)
 
 	args = createTokenArgs{
-		role: "admin", issuer: keycloakIssuer, aud: shastaAud, typ: "Invalid"}
+		role: "admin", issuer: keycloakIssuer, aud: shastaAud, typ: "Invalid",
+	}
 	invalidTypAdminToken, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -147,7 +149,8 @@ func main() {
 	fmt.Println("Invalid typ admin token:", invalidTypAdminToken)
 
 	args = createTokenArgs{
-		role: "system-pxe", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer"}
+		role: "system-pxe", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer",
+	}
 	pxeToken, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -155,7 +158,8 @@ func main() {
 	fmt.Println("pxe token:", pxeToken)
 
 	args = createTokenArgs{
-		role: "system-compute", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer"}
+		role: "system-compute", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer",
+	}
 	computeToken, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -171,7 +175,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/invalid"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireInvalidSub, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -180,7 +185,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/workload/cfs-state-reporter"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCfsStateReporter, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -189,7 +195,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/workload/ckdump"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCkdump, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -198,7 +205,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/workload/ckdump_helper"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCkdumpHelper, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -207,7 +215,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/workload/cpsmount"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCpsmount, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -216,7 +225,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/workload/cpsmount_helper"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCpsmountHelper, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -225,7 +235,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/workload/dvs-hmi"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnDvsHmi, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -234,7 +245,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/workload/dvs-map"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnDvsMap, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -243,7 +255,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/workload/heartbeat"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnHeartbeat, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -252,7 +265,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/workload/orca"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnOrca, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -261,7 +275,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/workload/cfs-state-reporter"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCfsStateReporter, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -270,7 +285,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/workload/ckdump"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCkdump, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -279,7 +295,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/workload/ckdump_helper"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCkdumpHelper, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -288,7 +305,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/workload/cpsmount"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCpsmount, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -297,7 +315,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/workload/cpsmount_helper"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCpsmountHelper, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -306,7 +325,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/workload/dvs-hmi"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeDvsHmi, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -315,7 +335,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/workload/dvs-map"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeDvsMap, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -324,7 +345,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/workload/heartbeat"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeHeartbeat, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -333,7 +355,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/workload/orca"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeOrca, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -342,7 +365,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/workload/wlm"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeWlm, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -417,7 +441,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println("Read the test template file %v", string(dat))
+	fmt.Printf("Read the test template file %v", string(dat))
 
 	tpl = template.Must(
 		template.New("base").Funcs(sprig.FuncMap()).Parse(string(dat)))
@@ -497,9 +521,20 @@ func main() {
 	fmt.Printf("%s", greeting)
 	fmt.Println("*****")
 
+	fmt.Println("Executing ./opa_envoy_linux_amd64 check -S ./policy.rego ./test.rego")
+
+	cmd := exec.Command("./opa_envoy_linux_amd64", "check", "-S", "./policy.rego")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	fmt.Println("Executing ./opa_envoy_linux_amd64 test ./policy.rego ./test.rego -v")
 
-	cmd := exec.Command("./opa_envoy_linux_amd64", "test", "./policy.rego", "./test.rego", "-v")
+	cmd = exec.Command("./opa_envoy_linux_amd64", "test", "./policy.rego", "./test.rego", "-v")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/kubernetes/cray-opa/tests/opa/run_tests/run_tests.go
+++ b/kubernetes/cray-opa/tests/opa/run_tests/run_tests.go
@@ -520,6 +520,9 @@ func main() {
 
 	fmt.Printf("%s", greeting)
 	fmt.Println("*****")
+	fmt.Printf("Policy File: %s\n", policyTemplateFilename)
+	fmt.Printf("Test File: %s\n", testTemplateFilename)
+	fmt.Printf("Template: %s\n", policyTemplateName)
 
 	fmt.Println("Executing ./opa_envoy_linux_amd64 check -S ./policy.rego ./test.rego")
 

--- a/kubernetes/cray-opa/tests/opa/xname-disabled/Dockerfile
+++ b/kubernetes/cray-opa/tests/opa/xname-disabled/Dockerfile
@@ -25,9 +25,9 @@
 FROM arti.dev.cray.com/baseos-docker-master-local/golang:1.14.9-alpine3.12 AS builder
 
 ENV GO111MODULE=on \
-    CGO_ENABLED=0 \
-    GOOS=linux \
-    GOARCH=amd64
+  CGO_ENABLED=0 \
+  GOOS=linux \
+  GOARCH=amd64
 
 COPY tests/opa/xname-disabled/run_tests src/run_tests
 
@@ -35,7 +35,7 @@ RUN cd src/run_tests && go mod download
 RUN cd src/run_tests && go build .
 RUN ls src/run_tests
 
-FROM artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.26.0-envoy-6
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
 
 COPY --from=builder /go/src/run_tests/run_tests .
 COPY tests/opa/certificate_authority.crt /jwtValidationFetchTls/certificate_authority.crt

--- a/kubernetes/cray-opa/tests/opa/xname-disabled/run_tests/run_tests.go
+++ b/kubernetes/cray-opa/tests/opa/xname-disabled/run_tests/run_tests.go
@@ -124,7 +124,8 @@ func main() {
 	var spireSub string
 
 	args := createTokenArgs{
-		role: "admin", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer"}
+		role: "admin", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer",
+	}
 	adminToken, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -146,7 +147,8 @@ func main() {
 	fmt.Println("Invalid typ admin token:", invalidTypAdminToken)
 
 	args = createTokenArgs{
-		role: "system-pxe", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer"}
+		role: "system-pxe", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer",
+	}
 	pxeToken, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -154,7 +156,8 @@ func main() {
 	fmt.Println("pxe token:", pxeToken)
 
 	args = createTokenArgs{
-		role: "system-compute", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer"}
+		role: "system-compute", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer",
+	}
 	computeToken, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -170,7 +173,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/invalid"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireInvalidSub, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -179,7 +183,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/cfs-state-reporter"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCfsStateReporter, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -188,7 +193,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/ckdump"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCkdump, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -197,7 +203,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/ckdump_helper"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCkdumpHelper, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -206,7 +213,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/cpsmount"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCpsmount, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -215,7 +223,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/cpsmount_helper"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCpsmountHelper, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -224,7 +233,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/dvs-hmi"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnDvsHmi, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -233,7 +243,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/dvs-map"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnDvsMap, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -242,7 +253,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/heartbeat"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnHeartbeat, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -251,7 +263,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/orca"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnOrca, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -260,7 +273,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/cfs-state-reporter"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCfsStateReporter, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -269,7 +283,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/ckdump"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCkdump, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -278,7 +293,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/ckdump_helper"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCkdumpHelper, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -287,7 +303,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/cpsmount"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCpsmount, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -296,7 +313,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/cpsmount_helper"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCpsmountHelper, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -305,7 +323,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/dvs-hmi"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeDvsHmi, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -314,7 +333,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/dvs-map"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeDvsMap, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -323,7 +343,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/heartbeat"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeHeartbeat, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -332,7 +353,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/orca"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeOrca, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -341,7 +363,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/wlm"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeWlm, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -422,7 +445,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println("Read the test template file %v", string(dat))
+	fmt.Printf("Read the test template file %v", string(dat))
 
 	tpl = template.Must(
 		template.New("base").Funcs(sprig.FuncMap()).Parse(string(dat)))
@@ -502,9 +525,20 @@ func main() {
 	fmt.Printf("%s", greeting)
 	fmt.Println("*****")
 
+	fmt.Println("Executing ./opa_envoy_linux_amd64 check -S ./policy.rego ./test.rego")
+
+	cmd := exec.Command("./opa_envoy_linux_amd64", "check", "-S", "./policy.rego")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	fmt.Println("Executing ./opa_envoy_linux_amd64 test ./policy.rego ./test.rego -v")
 
-	cmd := exec.Command("./opa_envoy_linux_amd64", "test", "./policy.rego", "./test.rego", "-v")
+	cmd = exec.Command("./opa_envoy_linux_amd64", "test", "./policy.rego", "./test.rego", "-v")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/kubernetes/cray-opa/tests/opa/xname-disabled/run_tests/run_tests.go
+++ b/kubernetes/cray-opa/tests/opa/xname-disabled/run_tests/run_tests.go
@@ -524,6 +524,9 @@ func main() {
 
 	fmt.Printf("%s", greeting)
 	fmt.Println("*****")
+	fmt.Printf("Policy File: %s\n", policyTemplateFilename)
+	fmt.Printf("Test File: %s\n", testTemplateFilename)
+	fmt.Printf("Template: %s\n", policyTemplateName)
 
 	fmt.Println("Executing ./opa_envoy_linux_amd64 check -S ./policy.rego ./test.rego")
 

--- a/kubernetes/cray-opa/tests/opa/xname-enabled/Dockerfile
+++ b/kubernetes/cray-opa/tests/opa/xname-enabled/Dockerfile
@@ -25,9 +25,9 @@
 FROM arti.dev.cray.com/baseos-docker-master-local/golang:1.14.9-alpine3.12 AS builder
 
 ENV GO111MODULE=on \
-    CGO_ENABLED=0 \
-    GOOS=linux \
-    GOARCH=amd64
+  CGO_ENABLED=0 \
+  GOOS=linux \
+  GOARCH=amd64
 
 COPY tests/opa/xname-enabled/run_tests src/run_tests
 
@@ -35,7 +35,7 @@ RUN cd src/run_tests && go mod download
 RUN cd src/run_tests && go build .
 RUN ls src/run_tests
 
-FROM artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.26.0-envoy-6
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
 
 COPY --from=builder /go/src/run_tests/run_tests .
 COPY tests/opa/certificate_authority.crt /jwtValidationFetchTls/certificate_authority.crt

--- a/kubernetes/cray-opa/tests/opa/xname-enabled/run_tests/run_tests.go
+++ b/kubernetes/cray-opa/tests/opa/xname-enabled/run_tests/run_tests.go
@@ -528,6 +528,9 @@ func main() {
 
 	fmt.Printf("%s", greeting)
 	fmt.Println("*****")
+	fmt.Printf("Policy File: %s\n", policyTemplateFilename)
+	fmt.Printf("Test File: %s\n", testTemplateFilename)
+	fmt.Printf("Template: %s\n", policyTemplateName)
 
 	fmt.Println("Executing ./opa_envoy_linux_amd64 check -S ./policy.rego ./test.rego")
 

--- a/kubernetes/cray-opa/tests/opa/xname-enabled/run_tests/run_tests.go
+++ b/kubernetes/cray-opa/tests/opa/xname-enabled/run_tests/run_tests.go
@@ -124,7 +124,8 @@ func main() {
 	var spireSub string
 
 	args := createTokenArgs{
-		role: "admin", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer"}
+		role: "admin", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer",
+	}
 	adminToken, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -146,7 +147,8 @@ func main() {
 	fmt.Println("Invalid typ admin token:", invalidTypAdminToken)
 
 	args = createTokenArgs{
-		role: "system-pxe", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer"}
+		role: "system-pxe", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer",
+	}
 	pxeToken, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -154,7 +156,8 @@ func main() {
 	fmt.Println("pxe token:", pxeToken)
 
 	args = createTokenArgs{
-		role: "system-compute", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer"}
+		role: "system-compute", issuer: keycloakIssuer, aud: shastaAud, typ: "Bearer",
+	}
 	computeToken, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -170,7 +173,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/invalid"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireInvalidSub, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -179,7 +183,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/cfs-state-reporter"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCfsStateReporter, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -188,7 +193,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/ckdump"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCkdump, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -197,7 +203,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/ckdump_helper"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCkdumpHelper, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -206,7 +213,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/cpsmount"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCpsmount, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -215,7 +223,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/cpsmount_helper"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnCpsmountHelper, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -224,7 +233,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/dvs-hmi"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnDvsHmi, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -233,7 +243,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/dvs-map"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnDvsMap, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -242,7 +253,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/heartbeat"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnHeartbeat, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -251,7 +263,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/ncn/ncnw001/workload/orca"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireNcnOrca, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -260,7 +273,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/cfs-state-reporter"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCfsStateReporter, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -269,7 +283,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/ckdump"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCkdump, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -278,7 +293,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/ckdump_helper"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCkdumpHelper, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -287,7 +303,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/cpsmount"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCpsmount, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -296,7 +313,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/cpsmount_helper"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeCpsmountHelper, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -305,7 +323,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/dvs-hmi"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeDvsHmi, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -314,7 +333,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/dvs-map"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeDvsMap, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -323,7 +343,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/heartbeat"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeHeartbeat, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -332,7 +353,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/orca"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeOrca, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -341,7 +363,8 @@ func main() {
 
 	spireSub = "spiffe://shasta/compute/x1/workload/wlm"
 	args = createTokenArgs{
-		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub}
+		issuer: spireIssuer, aud: systemComputeAud, sub: spireSub,
+	}
 	spireComputeWlm, err := tc.create(args)
 	if err != nil {
 		log.Fatal(err)
@@ -426,7 +449,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println("Read the test template file %v", string(dat))
+	fmt.Printf("Read the test template file %v", string(dat))
 
 	tpl = template.Must(
 		template.New("base").Funcs(sprig.FuncMap()).Parse(string(dat)))
@@ -506,9 +529,20 @@ func main() {
 	fmt.Printf("%s", greeting)
 	fmt.Println("*****")
 
+	fmt.Println("Executing ./opa_envoy_linux_amd64 check -S ./policy.rego ./test.rego")
+
+	cmd := exec.Command("./opa_envoy_linux_amd64", "check", "-S", "./policy.rego")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	fmt.Println("Executing ./opa_envoy_linux_amd64 test ./policy.rego ./test.rego -v")
 
-	cmd := exec.Command("./opa_envoy_linux_amd64", "test", "./policy.rego", "./test.rego", "-v")
+	cmd = exec.Command("./opa_envoy_linux_amd64", "test", "./policy.rego", "./test.rego", "-v")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -24,7 +24,7 @@
 ---
 image:
   repository: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa
-  tag: 0.26.0-envoy-6  # When changing this, also update tests/opa//Dockerfile.
+  tag: 0.42.1-envoy # When changing this, also update tests/opa//Dockerfile.
   pullPolicy: IfNotPresent
 
 priorityClassName: csm-high-priority-service
@@ -56,9 +56,9 @@ opa:
   port: 9191
   containerPort: 9191
   loglevel: info
-  query: data.istio.authz.allow  # this should never really change
+  query: data.istio.authz.allow # this should never really change
   tls:
-    enabled: false  # TODO once we have cert manager
+    enabled: false # TODO once we have cert manager
     secret: ""
   strategy:
     rollingUpdate:

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -24,7 +24,7 @@
 ---
 image:
   repository: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa
-  tag: 0.42.1-envoy # When changing this, also update tests/opa//Dockerfile.
+  tag: 0.42.1-envoy  # When changing this, also update tests/opa//Dockerfile.
   pullPolicy: IfNotPresent
 
 priorityClassName: csm-high-priority-service
@@ -56,9 +56,9 @@ opa:
   port: 9191
   containerPort: 9191
   loglevel: info
-  query: data.istio.authz.allow # this should never really change
+  query: data.istio.authz.allow  # this should never really change
   tls:
-    enabled: false # TODO once we have cert manager
+    enabled: false  # TODO once we have cert manager
     secret: ""
   strategy:
     rollingUpdate:


### PR DESCRIPTION
## Summary and Scope

- Update opa-envoy to 0.42.1
- Add opa rego strict check to validate opa code is written correctly for the current version
- Fix opa code that failed the strict check

## Issues and Related PRs


* Resolves [CASMPET-5793](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5793)


## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Validated pods started and didn't error. 
Further testing is needed on bare metal with all products installed.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

This is a major version bump and needs to be tested on a bare metal 1.3.0 system with all products installed to validate OPA is still functioning as expected.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

