### PR TITLE
CASMPET-5835 Enable spire for heartbeats

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.19.0
+version: 1.20.0
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -279,7 +279,8 @@ allowed_methods := {
     {"method": "PATCH", "path": `^/apis/hmnfd/hmi/v2/subscriptions/.*$`},
     {"method": "DELETE", "path": `^/apis/hmnfd/hmi/v2/subscriptions/.*$`},
     #HBTD -> allow a compute to send a heartbeat
-    {"method": "POST",  "path": `^/apis/hbtd/hmi/v1/heartbeat$`},
+    {"method": "POST", "path": `^/apis/hbtd/hmi/v1/heartbeat$`},
+    {"method": "POST", "path": `^/apis/hbtd/hmi/v1/heartbeat/.*$`},
 
 
   ],
@@ -450,10 +451,10 @@ spire_methods := {
   ],
   "heartbeat": [
     {{- if .Values.opa.xnamePolicy.heartbeat }}
-     {"method": "POST", "path": sprintf("^/apis/hbtd/v1/heartbeat/%v$", [parsed_spire_token.xname])},
+     {"method": "POST", "path": sprintf("^/apis/hbtd/hmi/v1/heartbeat/%v$", [parsed_spire_token.xname])},
     {{- else }}
      {"method": "POST", "path": `^/apis/hbtd/hmi/v1/heartbeat$`},
-     {"method": "POST", "path": `^/apis/hbtd/v1/heartbeat/.*$`},
+     {"method": "POST", "path": `^/apis/hbtd/hmi/v1/heartbeat/.*$`},
     {{- end }}
 
   ]

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -480,6 +480,7 @@ sub_match = {
     "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/ncn/XNAME/workload/heartbeat": spire_methods["heartbeat"],
     "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/ncn/XNAME/workload/orca": spire_methods["dvs"],
     "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/storage/XNAME/workload/cfs-state-reporter": spire_methods["cfs"],
+    "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/storage/XNAME/workload/heartbeat": spire_methods["heartbeat"],
     "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/uan/XNAME/workload/bos-state-reporter": spire_methods["bos"],
     "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/uan/XNAME/workload/cfs-state-reporter": spire_methods["cfs"],
     "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/uan/XNAME/workload/ckdump": spire_methods["ckdump"],
@@ -517,7 +518,11 @@ sub_match = {
     "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/ncn/workload/dvs-map": allowed_methods["system-compute"],
     "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/compute/workload/orca": allowed_methods["system-compute"],
     "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/ncn/workload/orca": allowed_methods["system-compute"],
-    "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/compute/workload/wlm": allowed_methods["wlm"]
+    "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/compute/workload/wlm": allowed_methods["wlm"],
+    "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/compute/workload/heartbeat": allowed_methods["system-compute"],
+    "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/ncn/workload/heartbeat": allowed_methods["system-compute"],
+    "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/storage/workload/heartbeat": allowed_methods["system-compute"],
+    "spiffe://{{ .Values.jwtValidation.spire.trustDomain }}/uan/workload/heartbeat": allowed_methods["system-compute"],
 }
 {{- end }}
 {{ end }}

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.invalid_xname.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.invalid_xname.rego.tpl
@@ -7,8 +7,8 @@ package istio.authz
 
 
 test_spire_heartbeat_wrong_xname {
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/hbtd/v1/heartbeat/invalid", "headers": {"authorization": "Bearer {{ .spire.compute.heartbeat }}"}, "body": "{\"Component\": \"invalid\",\"Hostname\": \"compute1\",\"NID\": \"0\",\"Status\": \"OK\",\"Timestamp\": \"2021-09-23T22:52:00.955107+00:00\"}" }}}}
-  allow.http_status  == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/hbtd/v1/heartbeat/invalid", "headers": {"authorization": "Bearer {{ .spire.ncn.heartbeat }}"}, "body": "{\"Component\": \"invalid\",\"Hostname\": \"ncn1\",\"NID\": \"0\",\"Status\": \"OK\",\"Timestamp\": \"2021-09-23T22:52:00.955107+00:00\"}" }}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/hbtd/hmi/v1/heartbeat/invalid", "headers": {"authorization": "Bearer {{ .spire.compute.heartbeat }}"}, "body": "{\"Component\": \"invalid\",\"Hostname\": \"compute1\",\"NID\": \"0\",\"Status\": \"OK\",\"Timestamp\": \"2021-09-23T22:52:00.955107+00:00\"}" }}}}
+  allow.http_status  == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/hbtd/hmi/v1/heartbeat/invalid", "headers": {"authorization": "Bearer {{ .spire.ncn.heartbeat }}"}, "body": "{\"Component\": \"invalid\",\"Hostname\": \"ncn1\",\"NID\": \"0\",\"Status\": \"OK\",\"Timestamp\": \"2021-09-23T22:52:00.955107+00:00\"}" }}}}
 }
 
 spire_wrong_xname_sub(sub) {

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
@@ -290,8 +290,8 @@ test_spire_compute_subs {
 }
 
 test_spire_heartbeat {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/hbtd/v1/heartbeat/x1", "headers": {"authorization": "Bearer {{ .spire.compute.heartbeat }}"}, "body": "{\"Component\": \"x1\",\"Hostname\": \"compute1\",\"NID\": \"0\",\"Status\": \"OK\",\"Timestamp\": \"2021-09-23T22:52:00.955107+00:00\"}" }}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/hbtd/v1/heartbeat/ncnw001", "headers": {"authorization": "Bearer {{ .spire.ncn.heartbeat }}"}, "body": "{\"Component\": \"ncnw001\",\"Hostname\": \"ncn1\",\"NID\": \"0\",\"Status\": \"OK\",\"Timestamp\": \"2021-09-23T22:52:00.955107+00:00\"}" }}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/hbtd/hmi/v1/heartbeat/x1", "headers": {"authorization": "Bearer {{ .spire.compute.heartbeat }}"}, "body": "{\"Component\": \"x1\",\"Hostname\": \"compute1\",\"NID\": \"0\",\"Status\": \"OK\",\"Timestamp\": \"2021-09-23T22:52:00.955107+00:00\"}" }}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/hbtd/hmi/v1/heartbeat/ncnw001", "headers": {"authorization": "Bearer {{ .spire.ncn.heartbeat }}"}, "body": "{\"Component\": \"ncnw001\",\"Hostname\": \"ncn1\",\"NID\": \"0\",\"Status\": \"OK\",\"Timestamp\": \"2021-09-23T22:52:00.955107+00:00\"}" }}}}
 }
 
 test_spire_cfs {

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -24,7 +24,7 @@
 ---
 image:
   repository: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa
-  tag: 0.42.1-envoy # When changing this, also update tests/opa//Dockerfile.
+  tag: 0.42.1-envoy  # When changing this, also update tests/opa//Dockerfile.
   pullPolicy: IfNotPresent
 
 priorityClassName: csm-high-priority-service
@@ -61,9 +61,9 @@ opa:
   port: 9191
   containerPort: 9191
   loglevel: info
-  query: data.istio.authz.allow # this should never really change
+  query: data.istio.authz.allow  # this should never really change
   tls:
-    enabled: false # TODO once we have cert manager
+    enabled: false  # TODO once we have cert manager
     secret: ""
   strategy:
     rollingUpdate:

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -24,7 +24,7 @@
 ---
 image:
   repository: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa
-  tag: 0.42.1-envoy  # When changing this, also update tests/opa//Dockerfile.
+  tag: 0.42.1-envoy # When changing this, also update tests/opa//Dockerfile.
   pullPolicy: IfNotPresent
 
 priorityClassName: csm-high-priority-service
@@ -61,9 +61,9 @@ opa:
   port: 9191
   containerPort: 9191
   loglevel: info
-  query: data.istio.authz.allow  # this should never really change
+  query: data.istio.authz.allow # this should never really change
   tls:
-    enabled: false  # TODO once we have cert manager
+    enabled: false # TODO once we have cert manager
     secret: ""
   strategy:
     rollingUpdate:
@@ -85,7 +85,7 @@ opa:
   # http.send requests default to 5s timeout. This was failing on a system so
   # increase this to 10s.
   httpTimeout: 10s
-  requireHeartbeatToken: false
+  requireHeartbeatToken: true
   xnamePolicy:
     enabled: false
     bos: false


### PR DESCRIPTION
## Summary and Scope

heartbeat is now using spire tokens by default. This disabled the spire authentication bypass for heartbeats and fixes issues with heartbeat spire access.

## Issues and Related PRs


* Resolves [CASMPET-5835](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5835)


## Testing

### Tested on:

  * `fanta`

### Test description:

Validated that storage nodes started heartbeating properly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

heartbeats with xname filtering enabled needs to be tested to validate the API URLs are correct.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

