### PR TITLE
PE-41317 Add support for gozerd and jackaloped

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.20.0
+version: 1.21.0
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-admin.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-admin.tpl
@@ -92,6 +92,9 @@ allow { startswith(original_path, "/service/rest") }
 # token from keycloak with the provided credentials.
 allow { startswith(original_path, "/capsules/") }
 
+# Whitelist gozerd (does its own MUNGE auth)
+allow { startswith(original_path, "/apis/gozerd/") }
+
 # This actually checks the JWT token passed in
 # has access to the endpoint requested
 allow {
@@ -166,12 +169,6 @@ allowed_methods := {
       {"method": "GET", "path": `^/apis/sma-telemetry-api/.*$`}, # All SMA telemetry API Calls - GET
   ],
   "wlm": [
-      # PALS - application launch
-      {"method": "GET", "path": `^/apis/pals/.*$`},
-      {"method": "HEAD", "path": `^/apis/pals/.*$`},
-      {"method": "POST", "path": `^/apis/pals/.*$`},
-      {"method": "DELETE", "path": `^/apis/pals/.*$`},
-
       # CAPMC - power capping and power control; eventually this will need to add PCS
         ## CAPMC -> Xnames
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/get_xname_status$`},
@@ -182,7 +179,6 @@ allowed_methods := {
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/get_power_cap$`},
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/get_power_cap_capabilities$`},
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/set_power_cap$`},
-
       # BOS - node boot
       {"method": "GET", "path": `^/apis/bos/.*$`},
       {"method": "HEAD", "path": `^/apis/bos/.*$`},
@@ -192,12 +188,16 @@ allowed_methods := {
       # SMD - hardware state query
       {"method": "GET",  "path": `^/apis/smd/hsm/v2/.*$`},
       {"method": "HEAD",  "path": `^/apis/smd/hsm/v2/.*$`},
-      # FC - VNI reservation
-      {"method": "GET", "path": `^/apis/fc/.*$`},
-      {"method": "HEAD", "path": `^/apis/fc/.*$`},
-      {"method": "POST", "path": `^/apis/fc/.*$`},
-      {"method": "PUT", "path": `^/apis/fc/.*$`},
-      {"method": "DELETE", "path": `^/apis/fc/.*$`},
+      # VNID - VNI reservation
+      {"method": "GET", "path": `^/apis/vnid/.*$`},
+      {"method": "HEAD", "path": `^/apis/vnid/.*$`},
+      {"method": "POST", "path": `^/apis/vnid/.*$`},
+      {"method": "DELETE", "path": `^/apis/vnid/.*$`},
+      # jackaloped - scalable startup
+      {"method": "GET", "path": `^/apis/jackaloped/.*$`},
+      {"method": "HEAD", "path": `^/apis/jackaloped/.*$`},
+      {"method": "POST", "path": `^/apis/jackaloped/.*$`},
+      {"method": "DELETE", "path": `^/apis/jackaloped/.*$`},
   ],
   "admin": [
       {"method": "GET",  "path": `.*`},

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-admin.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-admin.tpl
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2021 Hewlett Packard Enterprise Development LP
+Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 */ -}}
 {{ define "ingressgateway-customer-admin.policy" }}
 

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2021 Hewlett Packard Enterprise Development LP
+Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 */ -}}
 {{ define "ingressgateway-customer-user.policy" }}
 

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
@@ -93,6 +93,9 @@ allow { startswith(original_path, "/service/rest") }
 # token from keycloak with the provided credentials.
 allow { startswith(original_path, "/capsules/") }
 
+# Whitelist gozerd (does its own MUNGE auth)
+allow { startswith(original_path, "/apis/gozerd/") }
+
 # This actually checks that the JWT token passed in
 # has access to the endpoint requested
 allow {
@@ -168,12 +171,6 @@ allowed_methods := {
       {"method": "GET", "path": `^/apis/sma-telemetry-api/.*$`}, # All SMA telemetry API Calls - GET
   ],
   "wlm": [
-      # PALS - application launch
-      {"method": "GET", "path": `^/apis/pals/.*$`},
-      {"method": "HEAD", "path": `^/apis/pals/.*$`},
-      {"method": "POST", "path": `^/apis/pals/.*$`},
-      {"method": "DELETE", "path": `^/apis/pals/.*$`},
-
       # CAPMC - power capping and power control; eventually this will need to add PCS
         ## CAPMC -> Xnames
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/get_xname_status$`},
@@ -184,7 +181,6 @@ allowed_methods := {
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/get_power_cap$`},
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/get_power_cap_capabilities$`},
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/set_power_cap$`},
-
       # BOS - node boot
       {"method": "GET", "path": `^/apis/bos/.*$`},
       {"method": "HEAD", "path": `^/apis/bos/.*$`},
@@ -194,12 +190,16 @@ allowed_methods := {
       # SMD - hardware state query
       {"method": "GET",  "path": `^/apis/smd/hsm/v2/.*$`},
       {"method": "HEAD",  "path": `^/apis/smd/hsm/v2/.*$`},
-      # FC - VNI reservation
-      {"method": "GET", "path": `^/apis/fc/.*$`},
-      {"method": "HEAD", "path": `^/apis/fc/.*$`},
-      {"method": "POST", "path": `^/apis/fc/.*$`},
-      {"method": "PUT", "path": `^/apis/fc/.*$`},
-      {"method": "DELETE", "path": `^/apis/fc/.*$`},
+      # VNID - VNI reservation
+      {"method": "GET", "path": `^/apis/vnid/.*$`},
+      {"method": "HEAD", "path": `^/apis/vnid/.*$`},
+      {"method": "POST", "path": `^/apis/vnid/.*$`},
+      {"method": "DELETE", "path": `^/apis/vnid/.*$`},
+      # jackaloped - scalable startup
+      {"method": "GET", "path": `^/apis/jackaloped/.*$`},
+      {"method": "HEAD", "path": `^/apis/jackaloped/.*$`},
+      {"method": "POST", "path": `^/apis/jackaloped/.*$`},
+      {"method": "DELETE", "path": `^/apis/jackaloped/.*$`},
   ],
   "ckdump": [
       {"method": "GET",  "path": `^/apis/v2/nmd/.*$`},

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -96,6 +96,8 @@ allow { startswith(original_path, "/service/rest") }
 # token from keycloak with the provided credentials.
 allow { startswith(original_path, "/capsules/") }
 
+# Whitelist gozerd (does its own MUNGE auth)
+allow { startswith(original_path, "/apis/gozerd/") }
 
 {{- if not .Values.opa.requireHeartbeatToken }}
 # Allow heartbeats without requiring a spire token
@@ -285,12 +287,6 @@ allowed_methods := {
 
   ],
   "wlm": [
-      # PALS - application launch
-      {"method": "GET", "path": `^/apis/pals/.*$`},
-      {"method": "HEAD", "path": `^/apis/pals/.*$`},
-      {"method": "POST", "path": `^/apis/pals/.*$`},
-      {"method": "DELETE", "path": `^/apis/pals/.*$`},
-
       # CAPMC - power capping and power control; eventually this will need to add PCS
         ## CAPMC -> Xnames
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/get_xname_status$`},
@@ -301,7 +297,6 @@ allowed_methods := {
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/get_power_cap$`},
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/get_power_cap_capabilities$`},
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/set_power_cap$`},
-
       # BOS - node boot
       {"method": "GET", "path": `^/apis/bos/.*$`},
       {"method": "HEAD", "path": `^/apis/bos/.*$`},
@@ -321,8 +316,12 @@ allowed_methods := {
       {"method": "GET", "path": `^/apis/vnid/.*$`},
       {"method": "HEAD", "path": `^/apis/vnid/.*$`},
       {"method": "POST", "path": `^/apis/vnid/.*$`},
-      {"method": "PUT", "path": `^/apis/vnid/.*$`},
       {"method": "DELETE", "path": `^/apis/vnid/.*$`},
+      # jackaloped - scalable startup
+      {"method": "GET", "path": `^/apis/jackaloped/.*$`},
+      {"method": "HEAD", "path": `^/apis/jackaloped/.*$`},
+      {"method": "POST", "path": `^/apis/jackaloped/.*$`},
+      {"method": "DELETE", "path": `^/apis/jackaloped/.*$`},
   ],
   "admin": [
       {"method": "GET",  "path": `.*`},
@@ -410,12 +409,6 @@ spire_methods := {
     {{- end }}
   ],
   "wlm": [
-      # PALS - application launch
-      {"method": "GET", "path": `^/apis/pals/.*$`},
-      {"method": "HEAD", "path": `^/apis/pals/.*$`},
-      {"method": "POST", "path": `^/apis/pals/.*$`},
-      {"method": "DELETE", "path": `^/apis/pals/.*$`},
-
       # CAPMC - power capping and power control; eventually this will need to add PCS
         ## CAPMC -> Xnames
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/get_xname_status$`},
@@ -426,7 +419,6 @@ spire_methods := {
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/get_power_cap$`},
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/get_power_cap_capabilities$`},
       {"method": "POST", "path": `^/apis/capmc/capmc/v1/set_power_cap$`},
-
       # BOS - node boot
       {"method": "GET", "path": `^/apis/bos/.*$`},
       {"method": "HEAD", "path": `^/apis/bos/.*$`},
@@ -436,18 +428,16 @@ spire_methods := {
       # SMD - hardware state query
       {"method": "GET",  "path": `^/apis/smd/hsm/v2/.*$`},
       {"method": "HEAD",  "path": `^/apis/smd/hsm/v2/.*$`},
-      # FC - VNI reservation
-      {"method": "GET", "path": `^/apis/fc/.*$`},
-      {"method": "HEAD", "path": `^/apis/fc/.*$`},
-      {"method": "POST", "path": `^/apis/fc/.*$`},
-      {"method": "PUT", "path": `^/apis/fc/.*$`},
-      {"method": "DELETE", "path": `^/apis/fc/.*$`},
       # VNID - VNI reservation
       {"method": "GET", "path": `^/apis/vnid/.*$`},
       {"method": "HEAD", "path": `^/apis/vnid/.*$`},
       {"method": "POST", "path": `^/apis/vnid/.*$`},
-      {"method": "PUT", "path": `^/apis/vnid/.*$`},
       {"method": "DELETE", "path": `^/apis/vnid/.*$`},
+      # jackaloped - scalable startup
+      {"method": "GET", "path": `^/apis/jackaloped/.*$`},
+      {"method": "HEAD", "path": `^/apis/jackaloped/.*$`},
+      {"method": "POST", "path": `^/apis/jackaloped/.*$`},
+      {"method": "DELETE", "path": `^/apis/jackaloped/.*$`},
   ],
   "heartbeat": [
     {{- if .Values.opa.xnamePolicy.heartbeat }}

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
@@ -12,6 +12,7 @@ test_allow_bypassed_urls_with_no_auth_header {
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/capsules/"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/apis/gozerd/"}}}}
 }
 
 test_deny_tokens_api {
@@ -125,11 +126,6 @@ test_deny_compute {
 wlm_auth = "Bearer {{ .wlmToken }}"
 
 test_wlm {
-  # PALS - allowed
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/pals/v1/apps", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/pals/v1/apps", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/pals/v1/apps", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/pals/v1/apps", "headers": {"authorization": wlm_auth}}}}}
   # CAPMC - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_xname_status", "headers": {"authorization": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/xname_reinit", "headers": {"authorization": wlm_auth}}}}}
@@ -138,7 +134,6 @@ test_wlm {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_power_cap", "headers": {"authorization": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_power_cap_capabilities", "headers": {"authorization": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/set_power_cap", "headers": {"authorization": wlm_auth}}}}}
-
   # CAPMC - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/capmc/capmc/v1/set_power_cap", "headers": {"authorization": wlm_auth}}}}}
   # BOS - allowed
@@ -153,12 +148,20 @@ test_wlm {
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": wlm_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"authorization": wlm_auth}}}}}
-  # FC - allowed
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
+  # VNID - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  # VNID - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  # jackaloped - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
+  # jackaloped - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
 }
 
 # Tests for denying access to pals mock path for ckdump sub

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
@@ -1,4 +1,4 @@
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 
 package istio.authz
 ## HOW TO DO UNIT TESTING

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
@@ -1,4 +1,4 @@
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 
 package istio.authz
 ## HOW TO DO UNIT TESTING

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
@@ -12,6 +12,7 @@ test_allow_bypassed_urls_with_no_auth_header {
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/capsules/"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/apis/gozerd/"}}}}
 }
 
 test_deny_tokens_api {
@@ -129,11 +130,6 @@ test_deny_compute {
 wlm_auth = "{{ .wlmToken }}"
 
 test_wlm {
-  # PALS - allowed
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/pals/v1/apps", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/pals/v1/apps", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/pals/v1/apps", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/pals/v1/apps", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   # CAPMC - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_xname_status", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/xname_reinit", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
@@ -142,7 +138,6 @@ test_wlm {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_power_cap", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_power_cap_capabilities", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/set_power_cap", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-
   # CAPMC - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/capmc/capmc/v1/set_power_cap", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   # BOS - allowed
@@ -157,12 +152,20 @@ test_wlm {
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  # FC - allowed
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  # VNID - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  # VNID - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  # jackaloped - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  # jackaloped - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
 }
 
 # Tests for denying access to pals mock path for ckdump sub

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
@@ -12,6 +12,7 @@ test_allow_bypassed_urls_with_no_auth_header {
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/capsules/"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/apis/gozerd/"}}}}
 }
 
 test_deny_tokens_api {
@@ -124,11 +125,6 @@ test_deny_compute {
 wlm_auth = "Bearer {{ .wlmToken }}"
 
 test_wlm {
-  # PALS - allowed
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/pals/v1/apps", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/pals/v1/apps", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/pals/v1/apps", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/pals/v1/apps", "headers": {"authorization": wlm_auth}}}}}
   # CAPMC - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_xname_status", "headers": {"authorization": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/xname_reinit", "headers": {"authorization": wlm_auth}}}}}
@@ -137,7 +133,6 @@ test_wlm {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_power_cap", "headers": {"authorization": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_power_cap_capabilities", "headers": {"authorization": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/set_power_cap", "headers": {"authorization": wlm_auth}}}}}
-
   # CAPMC - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/capmc/capmc/v1/set_power_cap", "headers": {"authorization": wlm_auth}}}}}
   # BOS - allowed
@@ -152,12 +147,20 @@ test_wlm {
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": wlm_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"authorization": wlm_auth}}}}}
-  # FC - allowed
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
+  # VNID - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  # VNID - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  # jackaloped - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
+  # jackaloped - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
 }
 
 # Tests for denying access to pals mock path for ckdump sub

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
@@ -1,4 +1,4 @@
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 
 package istio.authz
 ## HOW TO DO UNIT TESTING

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
@@ -12,6 +12,7 @@ test_allow_bypassed_urls_with_no_auth_header {
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/capsules/"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/apis/gozerd/"}}}}
 }
 
 test_deny_tokens_api {
@@ -128,11 +129,6 @@ test_deny_compute {
 wlm_auth = "{{ .wlmToken }}"
 
 test_wlm {
-  # PALS - allowed
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/pals/v1/apps", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/pals/v1/apps", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/pals/v1/apps", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/pals/v1/apps", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   # CAPMC - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_xname_status", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/xname_reinit", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
@@ -141,7 +137,6 @@ test_wlm {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_power_cap", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_power_cap_capabilities", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/set_power_cap", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-
   # CAPMC - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/capmc/capmc/v1/set_power_cap", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   # BOS - allowed
@@ -156,12 +151,20 @@ test_wlm {
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  # FC - allowed
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  # VNID - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  # VNID - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  # jackaloped - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  # jackaloped - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
 }
 
 # Tests for denying access to pals mock path for ckdump sub

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
@@ -1,4 +1,4 @@
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 
 package istio.authz
 ## HOW TO DO UNIT TESTING

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-hmn_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-hmn_policy_test.rego.tpl
@@ -12,6 +12,7 @@ test_deny_bypassed_urls_with_no_auth_header {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/capsules/"}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/apis/gozerd/"}}}}
 }
 
 test_deny_tokens_api {

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-hmn_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-hmn_policy_test.rego.tpl
@@ -1,4 +1,4 @@
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 
 package istio.authz
 ## HOW TO DO UNIT TESTING

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
@@ -12,6 +12,7 @@ test_allow_bypassed_urls_with_no_auth_header {
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/capsules/"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/apis/gozerd/"}}}}
 }
 
 test_deny_tokens_endpoint {
@@ -130,11 +131,6 @@ test_compute {
 # Tests for wlm role
 
 wlm_sub(sub) {
-  # PALS - allowed
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/pals/v1/apps", "headers": {"authorization": sub}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/pals/v1/apps", "headers": {"authorization": sub}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/pals/v1/apps", "headers": {"authorization": sub}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/pals/v1/apps", "headers": {"authorization": sub}}}}}
   # CAPMC - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_xname_status", "headers": {"authorization": sub}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/xname_reinit", "headers": {"authorization": sub}}}}}
@@ -143,7 +139,6 @@ wlm_sub(sub) {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_power_cap", "headers": {"authorization": sub}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_power_cap_capabilities", "headers": {"authorization": sub}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/set_power_cap", "headers": {"authorization": sub}}}}}
-
   # CAPMC - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/capmc/capmc/v1/set_power_cap", "headers": {"authorization": sub}}}}}
   # BOS - allowed
@@ -158,18 +153,20 @@ wlm_sub(sub) {
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": sub}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"authorization": sub}}}}}
-  # FC - allowed
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": sub}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": sub}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": sub}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": sub}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": sub}}}}}
   # VNID - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": sub}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": sub}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": sub}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": sub}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": sub}}}}}
+  # VNID - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": sub}}}}}
+  # jackaloped - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": sub}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": sub}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": sub}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": sub}}}}}
+  # jackaloped - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": sub}}}}}
 }
 
 test_wlm {

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
@@ -12,6 +12,7 @@ test_allow_bypassed_urls_with_no_auth_header {
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/capsules/"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/apis/gozerd/"}}}}
 }
 
 test_deny_tokens_api {
@@ -140,11 +141,6 @@ test_compute {
 wlm_auth = "Bearer {{ .wlmToken }}"
 
 test_wlm {
-  # PALS - allowed
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/pals/v1/apps", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/pals/v1/apps", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/pals/v1/apps", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/pals/v1/apps", "headers": {"authorization": wlm_auth}}}}}
   # CAPMC - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_xname_status", "headers": {"authorization": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/xname_reinit", "headers": {"authorization": wlm_auth}}}}}
@@ -153,7 +149,6 @@ test_wlm {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_power_cap", "headers": {"authorization": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_power_cap_capabilities", "headers": {"authorization": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/set_power_cap", "headers": {"authorization": wlm_auth}}}}}
-
   # CAPMC - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/capmc/capmc/v1/set_power_cap", "headers": {"authorization": wlm_auth}}}}}
   # BOS - allowed
@@ -168,12 +163,20 @@ test_wlm {
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": wlm_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"authorization": wlm_auth}}}}}
-  # FC - allowed
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/fc/v2/port-sets", "headers": {"authorization": wlm_auth}}}}}
+  # VNID - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  # VNID - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/vnid/fabric/vnis", "headers": {"authorization": wlm_auth}}}}}
+  # jackaloped - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
+  # jackaloped - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": wlm_auth}}}}}
 }
 
 # Tests for denying access to pals mock path for ckdump sub

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
@@ -12,6 +12,7 @@ test_allow_bypassed_urls_with_no_auth_header {
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/capsules/"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/apis/gozerd/"}}}}
 }
 
 test_deny_tokens_endpoint {
@@ -137,11 +138,6 @@ test_compute {
 wlm_auth = "{{ .wlmToken }}"
 
 test_wlm {
-  # PALS - allowed
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/pals/v1/apps", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/pals/v1/apps", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/pals/v1/apps", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/pals/v1/apps", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   # CAPMC - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_xname_status", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/xname_reinit", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
@@ -150,7 +146,6 @@ test_wlm {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_power_cap", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/get_power_cap_capabilities", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/capmc/capmc/v1/set_power_cap", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-
   # CAPMC - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/capmc/capmc/v1/set_power_cap", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   # BOS - allowed
@@ -165,12 +160,20 @@ test_wlm {
   # SMD - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": wlm_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  # FC - allowed
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/fc/v2/port-sets", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  # VNID - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  # VNID - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/vnid/fabric/vnis", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  # jackaloped - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
+  # jackaloped - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/jackaloped/fabric/nics", "headers": {"x-forwarded-access-token": wlm_auth}}}}}
 }
 
 # Tests for denying access to pals mock path for ckdump sub


### PR DESCRIPTION
## Summary and Scope

Add a whitelist URL for gozerd, which does its own authentication using
MUNGE tokens.

Also, update the wlm role permissions with the following changes:
- The PALS API was removed, so remove the policy for it
- Replace FC API with VNID
- Add new jackaloped API for scalable startup support
- Remove unused PUT method for VNID/jackaloped

## Issues and Related PRs

* Resolves PE-41317

## Testing

### Tested on:

  * Local development environment

### Test description:

Tested with unit tests.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

