### PR TITLE
CASMPET-5840: whitelist keycloak for hmn

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.21.0
+version: 1.22.0
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-hmn.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-hmn.tpl
@@ -3,7 +3,7 @@ Copyright 2022 Hewlett Packard Enterprise Development LP
 */ -}}
 {{ define "ingressgateway-hmn.policy" }}
 
-# Istio Ingress Customer User Gateway OPA Policy
+# Istio Ingress HMN OPA Policy
 package istio.authz
 
 import input.attributes.request.http as http_request
@@ -47,6 +47,9 @@ allow {
 original_path = o_path {
     o_path := http_request.path
 }
+
+# Whitelist Keycloak, since those services enable users to login and obtain JWTs.
+allow { startswith(original_path, "/keycloak") }
 
 allow {
     roles_for_user[r]

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-hmn_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-hmn_policy_test.rego.tpl
@@ -5,8 +5,11 @@ package istio.authz
 # allow.http_status is 403 when the request is rejected due to the default allow.
 # allow.http_status is not present the request is successful because the result is true.
 
+test_allow_bypassed_urls_with_no_auth_header {
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+}
+
 test_deny_bypassed_urls_with_no_auth_header {
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}


### PR DESCRIPTION
## Summary and Scope

Allow keycloak token to be generated for hmn. The minor chart version was bumped.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5840](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5840)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `surtur`

### Test description:

Upgraded the cray-opa chart, and verified (by Jeanne) that the keycloak token can now be generated for hmn:
"Getting token for hmnlb
auth.hmnlb.surtur.hpc.amslabs.hpecorp.net is reachable
Token successfully retrieved at https://auth.hmnlb.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta/protocol/openid-connect/token"

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

