### PR TITLE
CASMPET-5856 Allow heartbeat params api

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.22.0
+version: 1.23.0
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -283,6 +283,7 @@ allowed_methods := {
     #HBTD -> allow a compute to send a heartbeat
     {"method": "POST", "path": `^/apis/hbtd/hmi/v1/heartbeat$`},
     {"method": "POST", "path": `^/apis/hbtd/hmi/v1/heartbeat/.*$`},
+    {"method": "GET", "path": `^/apis/hbtd/hmi/v1/params$`},
 
 
   ],
@@ -446,6 +447,7 @@ spire_methods := {
      {"method": "POST", "path": `^/apis/hbtd/hmi/v1/heartbeat$`},
      {"method": "POST", "path": `^/apis/hbtd/hmi/v1/heartbeat/.*$`},
     {{- end }}
+     {"method": "GET", "path": `^/apis/hbtd/hmi/v1/params$`},
 
   ]
 }

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
@@ -123,6 +123,7 @@ test_compute {
 
   # HBTD - Allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": hbtb_heartbeat_path, "headers": {"authorization": compute_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/hbtd/hmi/v1/params", "headers": {"authorization": "Bearer {{ .spire.compute.heartbeat }}"}}}}}
   # HBTD - Not Allowed
   # there is a global allow all on this path; so nothing can be not allowed;
 

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
@@ -295,6 +295,7 @@ test_spire_compute_subs {
 test_spire_heartbeat {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/hbtd/hmi/v1/heartbeat/x1", "headers": {"authorization": "Bearer {{ .spire.compute.heartbeat }}"}, "body": "{\"Component\": \"x1\",\"Hostname\": \"compute1\",\"NID\": \"0\",\"Status\": \"OK\",\"Timestamp\": \"2021-09-23T22:52:00.955107+00:00\"}" }}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/hbtd/hmi/v1/heartbeat/ncnw001", "headers": {"authorization": "Bearer {{ .spire.ncn.heartbeat }}"}, "body": "{\"Component\": \"ncnw001\",\"Hostname\": \"ncn1\",\"NID\": \"0\",\"Status\": \"OK\",\"Timestamp\": \"2021-09-23T22:52:00.955107+00:00\"}" }}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/hbtd/hmi/v1/params", "headers": {"authorization": "Bearer {{ .spire.compute.heartbeat }}"}}}}}
 }
 
 test_spire_cfs {


### PR DESCRIPTION
## Summary and Scope

This allows the heartbeat spire JWT to have access to `/apis/hbtd/hmi/v1/params`. This is used in the cray-heartbeat.sh script to request the heartbeat warning wait timeout.

## Issues and Related PRs


* Resolves [CASMPET-5856](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5856)

## Testing

### Tested on:

  * shandy

### Test description:

Validated that the cray-heartbeat script could successfully request the warning timeout from `/apis/hbtd/hmi/v1/params`.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, not needed for this change.
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

