### PR TITLE
CASMPET-5827 Remove unused hmcollector whitelist

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.23.0
+version: 1.24.0
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-admin.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-admin.tpl
@@ -7,7 +7,6 @@ Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 package istio.authz
 
 import input.attributes.request.http as http_request
-import input.attributes.source.address as source_address
 
 # Default return a 403 unless any of the allows are true
 default allow = {
@@ -15,29 +14,6 @@ default allow = {
   "headers": {"x-ext-auth-allow": "no"},
   "body": "Unauthorized Request",
   "http_status": 403
-}
-
-# Whitelist traffic to HMS hmcollector from the HMN and pod subnets
-allow {
-    # Limit scope to hmcollector to prevent unauthenticated access to other
-    # management services.
-    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
-    # HMN subnet (River)
-    net.cidr_contains("10.254.0.0/17", source_address.Address.SocketAddress.address)
-}
-allow {
-    # Limit scope to hmcollector to prevent unauthenticated access to other
-    # management services.
-    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
-    # HMN subnet (Mountain)
-    net.cidr_contains("10.100.106.0/23", source_address.Address.SocketAddress.address)
-}
-allow {
-    # Limit scope to hmcollector to prevent unauthenticated access to other
-    # management services.
-    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
-    # pod subnet
-    net.cidr_contains("10.32.0.0/12", source_address.Address.SocketAddress.address)
 }
 
 # Whitelist traffic to the Neuxs web UI since it uses Keycloak for authentication.

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
@@ -7,7 +7,6 @@ Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 package istio.authz
 
 import input.attributes.request.http as http_request
-import input.attributes.source.address as source_address
 
 # Default return a 403 unless any of the allows are true
 default allow = {
@@ -16,30 +15,6 @@ default allow = {
   "body": "Unauthorized Request",
   "http_status": 403
 }
-
-# Whitelist traffic to HMS hmcollector from the HMN and pod subnets
-allow {
-    # Limit scope to hmcollector to prevent unauthenticated access to other
-    # management services.
-    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
-    # HMN subnet (River)
-    net.cidr_contains("10.254.0.0/17", source_address.Address.SocketAddress.address)
-}
-allow {
-    # Limit scope to hmcollector to prevent unauthenticated access to other
-    # management services.
-    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
-    # HMN subnet (Mountain)
-    net.cidr_contains("10.100.106.0/23", source_address.Address.SocketAddress.address)
-}
-allow {
-    # Limit scope to hmcollector to prevent unauthenticated access to other
-    # management services.
-    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
-    # pod subnet
-    net.cidr_contains("10.32.0.0/12", source_address.Address.SocketAddress.address)
-}
-
 
 # Whitelist traffic to the Neuxs web UI since it uses Keycloak for authentication.
 allow {

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-hmn.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-hmn.tpl
@@ -16,7 +16,7 @@ default allow = {
   "http_status": 403
 }
 
-# Whitelist traffic to HMS hmcollector from the HMN and pod subnets
+# Whitelist traffic to HMS hmcollector
 allow {
     http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
 }

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-hmn.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-hmn.tpl
@@ -7,7 +7,6 @@ Copyright 2022 Hewlett Packard Enterprise Development LP
 package istio.authz
 
 import input.attributes.request.http as http_request
-import input.attributes.source.address as source_address
 
 # Default return a 403 unless any of the allows are true
 default allow = {
@@ -19,27 +18,8 @@ default allow = {
 
 # Whitelist traffic to HMS hmcollector from the HMN and pod subnets
 allow {
-    # Limit scope to hmcollector to prevent unauthenticated access to other
-    # management services.
     http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
-    # HMN subnet (River)
-    net.cidr_contains("10.254.0.0/17", source_address.Address.SocketAddress.address)
 }
-allow {
-    # Limit scope to hmcollector to prevent unauthenticated access to other
-    # management services.
-    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
-    # HMN subnet (Mountain)
-    net.cidr_contains("10.100.106.0/23", source_address.Address.SocketAddress.address)
-}
-allow {
-    # Limit scope to hmcollector to prevent unauthenticated access to other
-    # management services.
-    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
-    # pod subnet
-    net.cidr_contains("10.32.0.0/12", source_address.Address.SocketAddress.address)
-}
-
 
 # The path being requested from the user. When the envoy filter is configured for
 # SIDECAR_INBOUND this is: http_request.headers["x-envoy-original-path"].

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -7,7 +7,6 @@ Copyright 2021,2022 Hewlett Packard Enterprise Development LP
 package istio.authz
 
 import input.attributes.request.http as http_request
-import input.attributes.source.address as source_address
 
 # Default return a 403 unless any of the allows are true
 default allow = {
@@ -15,29 +14,6 @@ default allow = {
   "headers": {"x-ext-auth-allow": "no"},
   "body": "Unauthorized Request",
   "http_status": 403
-}
-
-# Whitelist traffic to HMS hmcollector from the HMN and pod subnets
-allow {
-    # Limit scope to hmcollector to prevent unauthenticated access to other
-    # management services.
-    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
-    # HMN subnet (River)
-    net.cidr_contains("10.254.0.0/17", source_address.Address.SocketAddress.address)
-}
-allow {
-    # Limit scope to hmcollector to prevent unauthenticated access to other
-    # management services.
-    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
-    # HMN subnet (Mountain)
-    net.cidr_contains("10.100.106.0/23", source_address.Address.SocketAddress.address)
-}
-allow {
-    # Limit scope to hmcollector to prevent unauthenticated access to other
-    # management services.
-    http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector.services.svc.cluster.local:80/*"
-    # pod subnet
-    net.cidr_contains("10.32.0.0/12", source_address.Address.SocketAddress.address)
 }
 
 # Whitelist traffic to the Neuxs web UI since it uses Keycloak for authentication.


### PR DESCRIPTION
## Summary and Scope

hmcollector access should only be available on the hmn gateway. In addition to this, source restrictions aren't possible due to our double SNAT issue and are being removed.

## Issues and Related PRs


* Resolves [CASMPET-5827](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5827)

## Testing

### Tested on:

  * Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why?  N, not possible to properly test without running on a fully installed CSM 1.3 system. Unit tests are sufficient to validate this change does not break any other access.
- Was downgrade tested? If not, why?N, not possible to properly test without running on a fully installed CSM 1.3 system. Unit tests are sufficient to validate this change does not break any other access.
- Were new tests (or test issues/Jiras) created for this change? N
## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

