### PR TITLE
CASMPET-5197 Fix hmnfd subscription api url

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.24.0
+version: 1.25.0
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -354,7 +354,7 @@ spire_methods := {
   "dvs": [
 
     {{- if .Values.opa.xnamePolicy.dvs }}
-    {"method": "GET", "path": sprintf("^/apis/hmnfd/hmi/v2/subscriptions/%v/agents$", [parsed_spire_token.xname])},
+    {"method": "GET", "path": sprintf("^/apis/hmnfd/hmi/v2/subscriptions/%v$", [parsed_spire_token.xname])},
     {"method": "POST", "path": sprintf("^/apis/hmnfd/hmi/v2/subscriptions/%v/agents/", [parsed_spire_token.xname])},
     {"method": "PATCH", "path": sprintf("^/apis/hmnfd/hmi/v2/subscriptions/%v/agents/", [parsed_spire_token.xname])},
     {"method": "DELETE", "path": sprintf("^/apis/hmnfd/hmi/v2/subscriptions/%v/agents/", [parsed_spire_token.xname])},

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.invalid_xname.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.invalid_xname.rego.tpl
@@ -18,7 +18,7 @@ spire_wrong_xname_sub(sub) {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/v2/nmd/dumps", "headers": {"authorization": sub}, "body": "{ \"xname\": [ \"invalid\" ] }"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/v2/nmd/dumps?xname=invalid", "headers": {"authorization": sub}}}}}
 
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/hmnfd/hmi/v2/subscriptions/invalid/agents", "headers": {"authorization": sub}, "body": "{\"Subscriber\": \"handler@invalid\"}"}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/hmnfd/hmi/v2/subscriptions/invalid", "headers": {"authorization": sub}, "body": "{\"Subscriber\": \"handler@invalid\"}"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/hmnfd/hmi/v2/subscriptions/invalid/agents/agent1", "headers": {"authorization": sub}, "body": "{\"Subscriber\": \"handler@invalid\"}"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/hmnfd/hmi/v2/subscriptions/invalid/agents/agent1", "headers": {"authorization": sub}, "body": "{\"Subscriber\": \"handler@invalid\"}"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/hmnfd/hmi/v2/subscriptions/invalid/agents/agent1", "headers": {"authorization": sub}, "body": "{\"Subscriber\": \"handler@invalid\"}"}}}}

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
@@ -217,7 +217,7 @@ spire_correct_ncn_sub(sub) {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": hmnfd_subscribe_path, "headers": {"authorization": sub}, "body": "{\"Subscriber\": \"handler@ncnw001\"}"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": hmnfd_subscribe_path, "headers": {"authorization": sub}}}}}
 
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/hmnfd/hmi/v2/subscriptions/ncnw001/agents", "headers": {"authorization": sub}, "body": "{\"Subscriber\": \"handler@ncnw001\"}"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/hmnfd/hmi/v2/subscriptions/ncnw001", "headers": {"authorization": sub}, "body": "{\"Subscriber\": \"handler@ncnw001\"}"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/hmnfd/hmi/v2/subscriptions/ncnw001/agents/agent1", "headers": {"authorization": sub}, "body": "{\"Subscriber\": \"handler@ncnw001\"}"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/hmnfd/hmi/v2/subscriptions/ncnw001/agents/agent1", "headers": {"authorization": sub}, "body": "{\"Subscriber\": \"handler@ncnw001\"}"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/hmnfd/hmi/v2/subscriptions/ncnw001/agents/agent1", "headers": {"authorization": sub}, "body": "{\"Subscriber\": \"handler@ncnw001\"}"}}}}


### PR DESCRIPTION
## Summary and Scope

This fixes an issue where the opa xname url was incorrectly set to `/apis/hmnfd/hmi/v2/subscriptions/%v/agents$` instead of `/apis/hmnfd/hmi/v2/subscriptions/%v`.

## Issues and Related PRs

* Resolves [CASMPET-5197](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5197)
## Testing

### Tested on:

  * Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N, tested locally via unit tests
- Was downgrade tested? If not, why? N , tested locally via unit tests
- Were new tests (or test issues/Jiras) created for this change? Updated tests

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

