### PR TITLE
CASMPET-5924 Fix keycloak auth

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.27.0
+version: 1.28.0
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/examples/custom-keycloak.yaml
+++ b/kubernetes/cray-opa/examples/custom-keycloak.yaml
@@ -23,7 +23,7 @@ data:
 
     allow {
         roles_for_user[r]
-        required_roles[r]
+        required_custom_roles[r]
     }
 
     # Check if there is an authorization header and split the type from token
@@ -51,18 +51,18 @@ data:
     }
 
     # Determine if the path/verb requests is authorized based on the JWT roles
-    required_roles[r] {
-        perm := role_perms[r][_]
+    required_custom_roles[r] {
+        perm := custom_role_perms[r][_]
         perm.method = http_request.method
         re_match(perm.path, original_path)
     }
 
     # Our list of endpoints we accept based on roles.
-    role_perms = {
-        "custom": allowed_methods["custom"],
+    custom_role_perms = {
+        "custom": allowed_custom_methods["custom"],
     }
 
-    allowed_methods := {
+    allowed_custom_methods := {
       "custom": [
           # Custom API Access
           {"method": "DELETE", "path": `^/custom/api.*$`},

--- a/kubernetes/cray-opa/examples/custom-spire.yaml
+++ b/kubernetes/cray-opa/examples/custom-spire.yaml
@@ -23,7 +23,7 @@ data:
         [a_type, a_token] := split(http_request.headers.authorization, " ")
     }
 
-    spire_methods := {
+    custom_spire_methods := {
       "custom": [
         {"method": "DELETE", "path": `^/custom/api.*$`},
         {"method": "GET", "path": `^/custom/api.*$`},
@@ -54,11 +54,11 @@ data:
         s :=  replace(parsed_spire_token.payload.sub, parsed_spire_token.xname, "XNAME")
 
         # Test subject matches destination
-        perm := sub_match[s][_]
+        perm := custom_sub_match[s][_]
         perm.method = http_request.method
         re_match(perm.path, original_path)
     }
 
-    sub_match = {
-        "spiffe://shasta/compute/XNAME/workload/custom-spire-agent": spire_methods["custom"],
+    custom_sub_match = {
+        "spiffe://shasta/compute/XNAME/workload/custom-spire-agent": custom_spire_methods["custom"],
     }

--- a/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
@@ -76,7 +76,7 @@ data:
     # has access to the endpoint requested
     allow {
         roles_for_user[r]
-        required_roles[r]
+        required_admin_roles[r]
     }
 
     # Check if there is an authorization header and split the type from token
@@ -112,14 +112,14 @@ data:
     }
 
     # Determine if the path/verb requests is authorized based on the JWT roles
-    required_roles[r] {
-        perm := role_perms[r][_]
+    required_admin_roles[r] {
+        perm := admin_role_perms[r][_]
         perm.method = http_request.method
         re_match(perm.path, original_path)
     }
 
 
-    allowed_methods := {
+    allowed_admin_methods := {
       "admin": [
           {"method": "GET",  "path": `.*`},
           {"method": "PUT",  "path": `.*`},
@@ -132,8 +132,8 @@ data:
 
     # Our list of endpoints we accept based on roles.
     # The admin roll can make any call.
-    role_perms = {
-        "admin": allowed_methods["admin"],
+    admin_role_perms = {
+        "admin": allowed_admin_methods["admin"],
     }
 
 {{- end }}

--- a/kubernetes/cray-opa/templates/policies/keycloak-user.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-user.yaml
@@ -77,7 +77,7 @@ data:
     # has access to the endpoint requested
     allow {
         roles_for_user[r]
-        required_roles[r]
+        required_user_roles[r]
     }
 
     # Check if there is an authorization header and split the type from token
@@ -114,14 +114,14 @@ data:
     }
 
     # Determine if the path/verb requests is authorized based on the JWT roles
-    required_roles[r] {
-        perm := role_perms[r][_]
+    required_user_roles[r] {
+        perm := user_role_perms[r][_]
         perm.method = http_request.method
         re_match(perm.path, original_path)
     }
 
 
-    allowed_methods := {
+    allowed_user_methods := {
       "user": [
           # UAS
           {"method": "GET", "path": `^/apis/uas-mgr/v1/$`}, # Get UAS API Version
@@ -191,11 +191,11 @@ data:
     }
 
     # Our list of endpoints we accept based on roles.
-    role_perms = {
-        "user": allowed_methods["user"],
-        "wlm": allowed_methods["wlm"],
-        "ckdump": allowed_methods["ckdump"],
-        "monitor-ro": allowed_methods["monitor-ro"],
+    user_role_perms = {
+        "user": allowed_user_methods["user"],
+        "wlm": allowed_user_methods["wlm"],
+        "ckdump": allowed_user_methods["ckdump"],
+        "monitor-ro": allowed_user_methods["monitor-ro"],
     }
 {{- end }}
 {{- end }}

--- a/kubernetes/cray-opa/tests/kuttl/custompolicy.yaml
+++ b/kubernetes/cray-opa/tests/kuttl/custompolicy.yaml
@@ -23,7 +23,7 @@ data:
 
     allow {
         roles_for_user[r]
-        required_roles[r]
+        required_custom_roles[r]
     }
 
     # Check if there is an authorization header and split the type from token
@@ -53,18 +53,18 @@ data:
     }
 
     # Determine if the path/verb requests is authorized based on the JWT roles
-    required_roles[r] {
-        perm := role_perms[r][_]
+    required_custom_roles[r] {
+        perm := custom_role_perms[r][_]
         perm.method = http_request.method
         re_match(perm.path, original_path)
     }
 
     # Our list of endpoints we accept based on roles.
-    role_perms = {
-        "custom": allowed_methods["custom"],
+    custom_role_perms = {
+        "custom": allowed_custom_methods["custom"],
     }
 
-    allowed_methods := {
+    allowed_custom_methods := {
       "custom": [
           # Custom API Access
           {"method": "DELETE", "path": `^/custom/api.*$`},


### PR DESCRIPTION
## Summary and Scope

This changes the name for keycloak admin and keycloak methods and role objects. If these are the same then the URL filtering fails and all requests using a valid keycloak JWTs throw 503s. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5924](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5924)

## Testing

### Tested on:

  * Local development environment
  * Virtual Shasta

### Test description:

Created a user and admin keycloak user and validated requests to a few API endpoints using curl.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

