### PR TITLE
CASMINST-5400 Add missing system keycloak rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ rego_test:
 	docker build -f ${CHART_PATH}/cray-opa/tests/opa/Dockerfile --tag cray-opa-test ${CHART_PATH}/cray-opa
 	docker run --rm -v ${PWD}/${CHART_PATH}/cray-opa/:/mnt --entrypoint "/app/run_tests" cray-opa-test /mnt/templates/policies/hmn.yaml /mnt/tests/opa/hmn_test.rego.tpl
 	docker run --rm -v ${PWD}/${CHART_PATH}/cray-opa/:/mnt --entrypoint "/app/run_tests" cray-opa-test /mnt/templates/policies/keycloak-admin.yaml /mnt/tests/opa/keycloak-admin_test.rego.tpl
+	docker run --rm -v ${PWD}/${CHART_PATH}/cray-opa/:/mnt --entrypoint "/app/run_tests" cray-opa-test /mnt/templates/policies/keycloak-system.yaml /mnt/tests/opa/keycloak-system_test.rego.tpl
 	docker run --rm -v ${PWD}/${CHART_PATH}/cray-opa/:/mnt --entrypoint "/app/run_tests" cray-opa-test /mnt/templates/policies/keycloak-user.yaml /mnt/tests/opa/keycloak-user_test.rego.tpl
 	docker run --rm -v ${PWD}/${CHART_PATH}/cray-opa/:/mnt --entrypoint "/app/run_tests" cray-opa-test /mnt/templates/policies/spire.yaml /mnt/tests/opa/spire_test.rego.tpl
 	docker run --rm -v ${PWD}/${CHART_PATH}/cray-opa/:/mnt --entrypoint "/app/run_tests" cray-opa-test -x /mnt/templates/policies/spire.yaml /mnt/tests/opa/spire_test.rego.tpl

--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.28.1
+version: 1.29.0
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/Makefile
+++ b/kubernetes/cray-opa/Makefile
@@ -42,5 +42,6 @@ rego_test:
 	docker run --rm -v $(current_dir)/:/mnt --entrypoint "/app/run_tests" cray-opa-test /mnt/templates/policies/keycloak-admin.yaml /mnt/tests/opa/keycloak-admin_test.rego.tpl
 	docker run --rm -v $(current_dir)/:/mnt --entrypoint "/app/run_tests" cray-opa-test /mnt/templates/policies/keycloak-user.yaml /mnt/tests/opa/keycloak-user_test.rego.tpl
 	docker run --rm -v $(current_dir)/:/mnt --entrypoint "/app/run_tests" cray-opa-test /mnt/templates/policies/spire.yaml /mnt/tests/opa/spire_test.rego.tpl
+	docker run --rm -v $(current_dir)/:/mnt --entrypoint "/app/run_tests" cray-opa-test -x /mnt/templates/policies/keycloak-system.yaml /mnt/tests/opa/keycloak-system_test.rego.tpl
 	docker run --rm -v $(current_dir)/:/mnt --entrypoint "/app/run_tests" cray-opa-test -x /mnt/templates/policies/spire.yaml /mnt/tests/opa/spire_test.rego.tpl
 	docker run --rm -v $(current_dir)/:/mnt --entrypoint "/app/run_tests" cray-opa-test -x /mnt/templates/policies/spire.yaml /mnt/tests/opa/spire_xname_test.rego.tpl

--- a/kubernetes/cray-opa/templates/deployment.yaml
+++ b/kubernetes/cray-opa/templates/deployment.yaml
@@ -129,6 +129,13 @@ spec:
                 - key: policy.rego
                   path: keycloakuser.rego
           {{- end}}
+          {{- if $options.policies.keycloak.system }}
+          - configMap:
+              name: opa-policy-{{ $name }}-keycloak-system
+              items:
+                - key: policy.rego
+                  path: keycloaksystem.rego
+          {{- end}}
           {{- range $customConfigMap := $options.policies.custom }}
           - configMap:
               name: {{ $customConfigMap }}

--- a/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
@@ -1,0 +1,144 @@
+{{- /*
+Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+*/ -}}
+{{- range $name, $options := .Values.ingresses }}
+{{- if $options.policies.keycloak.system }}
+{{- $policy := printf "%s-%s" $name "-keycloak-system.policy"}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opa-policy-{{ $name }}-keycloak-system
+  namespace: {{ $.Release.Namespace }}
+data:
+  policy.rego: |-
+    # Keycloak System Gateway OPA Policy
+    package istio.authz
+
+
+    import input.attributes.request.http as http_request
+
+
+    # The path being requested from the user. When the envoy filter is configured for
+    # SIDECAR_INBOUND this is: http_request.headers["x-envoy-original-path"].
+    # When configured for GATEWAY this is http_request.path
+    original_path = o_path {
+        o_path := http_request.path
+    }
+
+    # Whitelist Keycloak, since those services enable users to login and obtain
+    # JWTs. vcs is also enabled here. Legacy services to be migrated or removed:
+    #
+    #     * VCS/Gitea
+    #
+    allow { startswith(original_path, "/keycloak") }
+    allow { startswith(original_path, "/vcs") }
+
+    # Allow cloud-init endpoints, as we do validation based on incoming IP.
+    # In the future, these requests will come in via the TOR switches and ideally
+    # not through the 'front door'.   This is an expansion to BSS.
+    allow { startswith(original_path, "/meta-data") }
+    allow { startswith(original_path, "/user-data") }
+    allow { startswith(original_path, "/phone-home") }
+
+    # Whitelist Nexus repository pods. Nexus uses it's own RBAC so open
+    # all commands. Keycloak Gatekeeper is used to pass the tokens through
+    allow { startswith(original_path, "/repository") }
+    allow { startswith(original_path, "/v2") }
+    allow { startswith(original_path, "/service/rest") }
+
+    # This actually checks that the JWT token passed in
+    # has access to the endpoint requested
+    allow {
+        roles_for_user[r]
+        required_system_roles[r]
+    }
+
+    # Check if there is an authorization header and split the type from token
+    found_auth = {"type": a_type, "token": a_token} {
+        [a_type, a_token] := split(http_request.headers.authorization, " ")
+    }
+
+    # Check if there is a forwarded access token header and split the type from token
+    found_auth = {"type": a_type, "token": a_token} {
+      a_token := http_request.headers["x-forwarded-access-token"]
+      [_, payload, _] := io.jwt.decode(a_token)
+      a_type := payload.typ
+    }
+
+    # If the auth type is bearer, decode the JWT
+    parsed_kc_token = {"payload": payload} {
+        found_auth.type == "Bearer"
+        response := http.send({"method": "get", "url": "{{ $.Values.jwtValidation.keycloak.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt"})
+        [_, _, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "shasta"})
+
+        # Verify that the issuer is as expected.
+        allowed_issuers := [
+    {{- range $key, $value := $options.issuers }}
+          "{{ $value }}",
+    {{- end }}
+        ]
+        allowed_issuers[_] = payload.iss
+    }
+
+
+    # Get the users roles from the JWT token
+    roles_for_user[r] {
+        r := parsed_kc_token.payload.resource_access.shasta.roles[_]
+    }
+
+    # Determine if the path/verb requests is authorized based on the JWT roles
+    required_system_roles[r] {
+        perm := system_role_perms[r][_]
+        perm.method = http_request.method
+        re_match(perm.path, original_path)
+    }
+
+
+    allowed_system_methods := {
+      "system-pxe": [
+
+      #BSS -> computes need to retrieve boot scripts
+         {"method": "GET",  "path": `^/apis/bss/boot/v1/bootscript.*$`},
+         {"method": "HEAD",  "path": `^/apis/bss/boot/v1/bootscript.*$`},
+      ],
+      "system-compute": [
+        {"method": "PATCH",  "path": `^/apis/bos/v./components/.*$`},
+
+        {"method": "PATCH",  "path": `^/apis/cfs/components/.*$`},
+        {"method": "PATCH",  "path": `^/apis/cfs/v./components/.*$`},
+
+        {"method": "GET",  "path": `^/apis/v2/cps/transports`},
+        {"method": "POST",  "path": `^/apis/v2/cps/contents$`},
+        {"method": "POST",  "path": `^/apis/v2/cps/transports$`},
+
+        {"method": "PUT",  "path": `^/apis/v2/nmd/status/.*$`},
+
+        #SMD -> GET everything, DVS currently needs to update BulkSoftwareStatus
+        {"method": "GET",  "path": `^/apis/smd/hsm/v./.*$`},
+        {"method": "HEAD",  "path": `^/apis/smd/hsm/v./.*$`},
+        {"method": "PATCH",  "path": `^/apis/smd/hsm/v./State/Components/BulkSoftwareStatus$`},
+        #HMNFD -> subscribe only, cannot create state change notifications
+        {"method": "GET",  "path": `^/apis/hmnfd/hmi/v1/subscriptions$`},
+        {"method": "HEAD",  "path": `^/apis/hmnfd/hmi/v1/subscriptions$`},
+        {"method": "PATCH",  "path": `^/apis/hmnfd/hmi/v1/subscribe$`},
+        {"method": "POST",  "path": `^/apis/hmnfd/hmi/v1/subscribe$`},
+        {"method": "DELETE",  "path": `^/apis/hmnfd/hmi/v1/subscribe$`},
+        {"method": "GET", "path": `^/apis/hmnfd/hmi/v2/subscriptions/.*$`},
+        {"method": "POST", "path": `^/apis/hmnfd/hmi/v2/subscriptions/.*$`},
+        {"method": "PATCH", "path": `^/apis/hmnfd/hmi/v2/subscriptions/.*$`},
+        {"method": "DELETE", "path": `^/apis/hmnfd/hmi/v2/subscriptions/.*$`},
+        #HBTD -> allow a compute to send a heartbeat
+        {"method": "POST", "path": `^/apis/hbtd/hmi/v1/heartbeat$`},
+        {"method": "POST", "path": `^/apis/hbtd/hmi/v1/heartbeat/.*$`},
+        {"method": "GET", "path": `^/apis/hbtd/hmi/v1/params$`},
+      ]
+    }
+
+    # Our list of endpoints we accept based on roles.
+    system_role_perms = {
+      "system-pxe": allowed_system_methods["system-pxe"],
+      "system-compute": allowed_system_methods["system-compute"],
+    }
+{{- end }}
+{{- end }}

--- a/kubernetes/cray-opa/tests/kuttl/deployment/00-assert.yaml
+++ b/kubernetes/cray-opa/tests/kuttl/deployment/00-assert.yaml
@@ -84,6 +84,11 @@ spec:
                     - key: policy.rego
                       path: keycloakuser.rego
                   name: opa-policy-ingressgateway-keycloak-user
+              - configMap:
+                  items:
+                    - key: policy.rego
+                      path: keycloaksystem.rego
+                  name: opa-policy-ingressgateway-keycloak-system
         - configMap:
             defaultMode: 420
             name: cray-configmap-ca-public-key

--- a/kubernetes/cray-opa/tests/opa/keycloak-system_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/keycloak-system_test.rego.tpl
@@ -1,0 +1,109 @@
+# Copyright 2021,2022 Hewlett Packard Enterprise Development LP
+
+package istio.authz
+## HOW TO DO UNIT TESTING
+# allow.http_status is 403 when the request is rejected due to the default allow.
+# allow.http_status is not present the request is successful because the result is true.
+
+test_allow_bypassed_urls_with_no_auth_header {
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
+}
+
+test_user_when_admin_required {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/api1", "headers": {"authorization": "Bearer {{ .userToken }}"}}}}}
+}
+
+# Tests for system-pxe role
+
+pxe_auth = "Bearer {{ .pxeToken }}"
+
+bss_good_path = "/apis/bss/boot/v1/bootscript"
+bss_bad_path = "/apis/bss/boot/v1/anotherpath"
+
+test_pxe {
+
+  # BSS - Allowed
+
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": bss_good_path, "headers": {"authorization": pxe_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": bss_good_path, "headers": {"authorization": pxe_auth}}}}}
+
+  # BSS - Not Allowed
+
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": bss_bad_path, "headers": {"authorization": pxe_auth}}}}}
+
+}
+
+# Tests for system-compute role
+
+compute_auth = "Bearer {{ .computeToken }}"
+
+cfs_mock_path = "/apis/cfs/components/mock"
+hbtb_heartbeat_path = "/apis/hbtd/hmi/v1/heartbeat"
+nmd_mock_path = "/apis/v2/nmd/mock"
+smd_statecomponents_path = "/apis/smd/hsm/v2/State/Components"
+hmnfd_subscribe_path = "/apis/hmnfd/hmi/v1/subscribe"
+hmnfd_subscriptions_path = "/apis/hmnfd/hmi/v1/subscriptions"
+
+pals_mock_path = "/apis/pals/v1/mock"
+
+test_compute {
+
+  # CFS - Allowed
+
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": cfs_mock_path, "headers": {"authorization": compute_auth}}}}}
+
+  # CFS - Not Allowed
+
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": cfs_mock_path, "headers": {"authorization": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": cfs_mock_path, "headers": {"authorization": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": cfs_mock_path, "headers": {"authorization": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": cfs_mock_path, "headers": {"authorization": compute_auth}}}}}
+
+  # CPS - Allowed
+
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/v2/cps/transports", "headers": {"authorization": compute_auth}}}}}
+
+
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/v2/cps/transports", "headers": {"authorization": compute_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/v2/cps/contents", "headers": {"authorization": compute_auth}}}}}
+
+  # NMD - Allowed
+
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/v2/nmd/status/x1", "headers": {"authorization": compute_auth}}}}}
+
+  # NMD - Not Allowed
+
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": nmd_mock_path, "headers": {"authorization": compute_auth}}}}}
+
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": nmd_mock_path, "headers": {"authorization": compute_auth}}}}}
+
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": nmd_mock_path, "headers": {"authorization": compute_auth}}}}}
+
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": nmd_mock_path, "headers": {"authorization": compute_auth}}}}}
+
+  # SMD - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v1/State/Components/BulkSoftwareStatus", "headers": {"authorization": compute_auth}}}}}
+
+  # SMD - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": smd_statecomponents_path, "headers": {"authorization": compute_auth}}}}}
+
+  # HMNFD - Allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": hmnfd_subscriptions_path, "headers": {"authorization": compute_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": hmnfd_subscriptions_path, "headers": {"authorization": compute_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": hmnfd_subscribe_path, "headers": {"authorization": compute_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": hmnfd_subscribe_path, "headers": {"authorization": compute_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": hmnfd_subscribe_path, "headers": {"authorization": compute_auth}}}}}
+  # HMNFD - Not Allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "TRACE", "path": hmnfd_subscribe_path, "headers": {"authorization": compute_auth}}}}}
+
+  # HBTD - Allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": hbtb_heartbeat_path, "headers": {"authorization": compute_auth}}}}}
+
+}

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -37,6 +37,7 @@ ingresses:
       keycloak:
         admin: true
         user: true
+        system: true
       spire: true
     # namespace of the ingress containers
     # this will likely be different than the OPA namespace
@@ -54,6 +55,7 @@ ingresses:
       keycloak:
         admin: true
         user: true
+        system: false
       spire: false
     namespace: istio-system
     labelSelector:
@@ -66,6 +68,7 @@ ingresses:
       keycloak:
         admin: false
         user: true
+        system: false
       spire: false
     namespace: istio-system
     labelSelector:
@@ -78,6 +81,7 @@ ingresses:
       keycloak:
         admin: false
         user: false
+        system: false
       spire: false
     namespace: istio-system
     labelSelector:


### PR DESCRIPTION
## Summary and Scope

When the opa policies were broken up by use the system-pxe and system-compute policies were not moved over. This creates a new policy group, keycloak-system, that's used on the main ingress.

## Issues and Related PRs


* Resolves [CASMINST-5400](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5400)
## Testing

### Tested on:

  * fanta
  * Local development environment

### Test description:

Validated that system-pxe keycloak access worked after applying and that it allowed nodes to continue booting.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, not needed
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

