### PR TITLE
CASMCMS-8269: Change BOS policy from bos-state-reporter to bos-reporter

### DIFF
--- a/kubernetes/cray-opa/CHANGELOG.md
+++ b/kubernetes/cray-opa/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ## [1.3.0]
 ### Changed
-- Added entries for BOS (CASMCMS-7355)
+- Added entries for BOS in OPA (CASMCMS-8269)
+- Added entries for BOS in Spire (CASMCMS-7355)
 - Added support for custom issuers per OPA policy (CASMPET-5150)
 - Fixed WLM workload Spiffe ID (PE-37951)
 - Replaced problematic xname validation support in POST requests with new API endpoints (CASMPET-3940)

--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.29.1
+version: 1.29.2
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/policies/spire.yaml
+++ b/kubernetes/cray-opa/templates/policies/spire.yaml
@@ -171,7 +171,7 @@ data:
       }
 
       sub_match = {
-          "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/XNAME/workload/bos-state-reporter": spire_methods["bos"],
+          "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/XNAME/workload/bos-reporter": spire_methods["bos"],
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/XNAME/workload/cfs-state-reporter": spire_methods["cfs"],
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/XNAME/workload/ckdump": spire_methods["ckdump"],
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/XNAME/workload/ckdump_helper": spire_methods["ckdump"],
@@ -183,7 +183,7 @@ data:
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/XNAME/workload/orca": spire_methods["dvs"],
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/XNAME/workload/tpm-provisioner": spire_methods["tpm-provisioner"],
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/XNAME/workload/wlm": spire_methods["wlm"],
-          "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/ncn/XNAME/workload/bos-state-reporter": spire_methods["bos"],
+          "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/ncn/XNAME/workload/bos-reporter": spire_methods["bos"],
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/ncn/XNAME/workload/cfs-state-reporter": spire_methods["cfs"],
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/ncn/XNAME/workload/cpsmount": spire_methods["cps"],
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/ncn/XNAME/workload/cpsmount_helper": spire_methods["cps"],
@@ -195,7 +195,7 @@ data:
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/storage/XNAME/workload/cfs-state-reporter": spire_methods["cfs"],
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/storage/XNAME/workload/heartbeat": spire_methods["heartbeat"],
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/storage/XNAME/workload/tpm-provisioner": spire_methods["tpm-provisioner"],
-          "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/uan/XNAME/workload/bos-state-reporter": spire_methods["bos"],
+          "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/uan/XNAME/workload/bos-reporter": spire_methods["bos"],
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/uan/XNAME/workload/cfs-state-reporter": spire_methods["cfs"],
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/uan/XNAME/workload/ckdump": spire_methods["ckdump"],
           "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/uan/XNAME/workload/ckdump_helper": spire_methods["ckdump"],
@@ -237,7 +237,7 @@ data:
     }
 
     sub_match = {
-        "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/workload/bos-state-reporter": spire_methods["bos"],
+        "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/workload/bos-reporter": spire_methods["bos"],
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/workload/cfs-state-reporter": spire_methods["cfs"],
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/workload/ckdump": spire_methods["ckdump"],
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/workload/ckdump_helper": spire_methods["ckdump"],
@@ -249,7 +249,7 @@ data:
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/workload/orca": spire_methods["dvs"],
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/workload/tpm-provisioner": spire_methods["tpm-provisioner"],
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/compute/workload/wlm": spire_methods["wlm"],
-        "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/ncn/workload/bos-state-reporter": spire_methods["bos"],
+        "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/ncn/workload/bos-reporter": spire_methods["bos"],
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/ncn/workload/cfs-state-reporter": spire_methods["cfs"],
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/ncn/workload/cpsmount": spire_methods["cps"],
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/ncn/workload/cpsmount_helper": spire_methods["cps"],
@@ -261,7 +261,7 @@ data:
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/storage/workload/cfs-state-reporter": spire_methods["cfs"],
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/storage/workload/heartbeat": spire_methods["heartbeat"],
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/storage/workload/tpm-provisioner": spire_methods["tpm-provisioner"],
-        "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/uan/workload/bos-state-reporter": spire_methods["bos"],
+        "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/uan/workload/bos-reporter": spire_methods["bos"],
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/uan/workload/cfs-state-reporter": spire_methods["cfs"],
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/uan/workload/ckdump": spire_methods["ckdump"],
         "spiffe://{{ $.Values.jwtValidation.spire.trustDomain }}/uan/workload/ckdump_helper": spire_methods["ckdump"],


### PR DESCRIPTION
## Summary and Scope

The script changed its name from bos-state-reporter to bos-reporter. The OPA policy needs to match the name of the script. Thus, it too must change.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMCMS-8269
## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `Shandy`

### Test description:

I changed the OPA policy on Shandy and test-booted a node using BOS V2. It worked.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? 
- Were continuous integration tests run? If not, why? No.
- Was upgrade tested? If not, why? No.
- Was downgrade tested? If not, why? No.
- Were new tests (or test issues/Jiras) created for this change? No.

## Risks and Mitigations

Low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

