### PR TITLE
CASMPET-6116 Fix TPM Workload

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.29.2
+version: 1.30.0
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/policies/spire.yaml
+++ b/kubernetes/cray-opa/templates/policies/spire.yaml
@@ -92,9 +92,9 @@ data:
         ],
         "tpm-provisioner": [
         {{- if and (eq $.Values.opa.xnamePolicy.tpmProvisioner true) (eq $.Values.opa.xnamePolicy.enabled true) }}
-            {"method": "GET", "path": sprintf("^/apis/tpm-provisioner/challenge/authorize?xname=%v&type=[A-Za-z0-9]*$", [parsed_spire_token.xname])},
+            {"method": "GET", "path": sprintf("^/apis/tpm-provisioner/authorize?xname=%v&type=[A-Za-z0-9]*$", [parsed_spire_token.xname])},
         {{- else}}
-            {"method": "GET", "path": `^/apis/tpm-provisioner/challenge/authorize.*$`},
+            {"method": "GET", "path": `^/apis/tpm-provisioner/authorize.*$`},
         {{- end}}
             {"method": "POST", "path": `^/apis/tpm-provisioner/challenge/request$`},
             {"method": "POST", "path": `^/apis/tpm-provisioner/challenge/submit$`},

--- a/kubernetes/cray-opa/tests/opa/spire_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/spire_test.rego.tpl
@@ -236,8 +236,8 @@ test_spire_invalid_sub {
 }
 
 test_tpm_provisioner {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/challenge/authorize?xname=ncnw001&type=ncn", "headers": {"authorization": "Bearer {{ .spire.ncn.tpm_provisioner }}" }}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/challenge/authorize?xname=x1&type=compute", "headers": {"authorization": "Bearer {{ .spire.compute.tpm_provisioner }}" }}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/authorize?xname=ncnw001&type=ncn", "headers": {"authorization": "Bearer {{ .spire.ncn.tpm_provisioner }}" }}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/authorize?xname=x1&type=compute", "headers": {"authorization": "Bearer {{ .spire.compute.tpm_provisioner }}" }}}}}
 
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/tpm-provisioner/challenge/request", "headers": {"authorization": "Bearer {{ .spire.ncn.tpm_provisioner }}" }}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/tpm-provisioner/challenge/submit", "headers": {"authorization": "Bearer {{ .spire.ncn.tpm_provisioner }}" }}}}}

--- a/kubernetes/cray-opa/tests/opa/spire_xname_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/spire_xname_test.rego.tpl
@@ -34,6 +34,6 @@ test_spire_wrong_xname_subs {
 }
 
 test_tpm_provisioner_wrong_xname {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/challenge/authorize?xname=invalid&type=ncn", "headers": {"authorization": "Bearer {{ .spire.ncn.tpm_provisioner }}" }}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/challenge/authorize?xname=invalid&type=compute", "headers": {"authorization": "Bearer {{ .spire.compute.tpm_provisioner }}" }}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/authorize?xname=invalid&type=ncn", "headers": {"authorization": "Bearer {{ .spire.ncn.tpm_provisioner }}" }}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/authorize?xname=invalid&type=compute", "headers": {"authorization": "Bearer {{ .spire.compute.tpm_provisioner }}" }}}}}
 }


### PR DESCRIPTION
## Summary and Scope

Fixes one of the TPM Provisioner OPA rules to match the actual TPM Provisioner URLs.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6116 ](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6116 )

## Testing

### Tested on:

  * Odin

### Test description:

Validated that the URLs are correct vs what's being used in the TPM Provisioner.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Yes
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? No
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

