### PR TITLE
CASMPET-6127: CVE-2020-10770 mitigation changes

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: cray-opa
 sources:
 - https://github.com/Cray-HPE/cray-opa
-version: 1.10.6
+version: 1.10.7

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
@@ -50,8 +50,13 @@ original_path = o_path {
 #     * VCS/Gitea
 #
 allow {
+    startswith(original_path, "/keycloak")
+    not re_match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
+}
+
+allow {
     any([
-        startswith(original_path, "/keycloak"),
+        #startswith(original_path, "/keycloak"),
         startswith(original_path, "/vcs"),
     ])
 }

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
@@ -56,7 +56,6 @@ allow {
 
 allow {
     any([
-        #startswith(original_path, "/keycloak"),
         startswith(original_path, "/vcs"),
     ])
 }

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -61,7 +61,6 @@ allow {
 
 allow {
     any([
-        #startswith(original_path, "/keycloak"),
         startswith(original_path, "/vcs"),
         startswith(original_path, "/spire-jwks-"),
     ])

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -55,8 +55,13 @@ original_body = o_path {
 #     * VCS/Gitea
 #
 allow {
+    startswith(original_path, "/keycloak")
+    not re_match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
+}
+
+allow {
     any([
-        startswith(original_path, "/keycloak"),
+        #startswith(original_path, "/keycloak"),
         startswith(original_path, "/vcs"),
         startswith(original_path, "/spire-jwks-"),
     ])

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
@@ -32,6 +32,10 @@ test_user {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/uas-mgr/v1/", "headers": {"authorization": "Bearer {{ .userToken }}"}}}}}
 }
 
+test_ssrf {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/master/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
+}
+
 test_deny_admin {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/api1", "headers": {"authorization": "Bearer {{ .adminToken }}"}}}}}
 }

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
@@ -32,6 +32,10 @@ test_user {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/uas-mgr/v1/", "headers": {"authorization": "Bearer {{ .userToken }}"}}}}}
 }
 
+test_ssrf {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/master/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
+}
+
 test_admin {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/api1", "headers": {"authorization": "Bearer {{ .adminToken }}"}}}}}
 }


### PR DESCRIPTION
## Summary and Scope

CVE-2020-10770 Mitigation changes

## Testing

### Before Policy Modification

Enabling debug logs:

```ncn-m001:/tmp # kubectl edit deployment -n opa cray-opa-ingressgateway
deployment.apps/cray-opa-ingressgateway edited
ncn-m001:/tmp # kubectl edit deployment -n opa cray-opa-ingressgateway-customer-user
deployment.apps/cray-opa-ingressgateway-customer-user edited
ncn-m001:/tmp # kubectl rollout restart -n opa deployment cray-opa-ingressgateway
deployment.apps/cray-opa-ingressgateway restarted
ncn-m001:/tmp # kubectl rollout restart -n opa deployment cray-opa-ingressgateway-customer-user
deployment.apps/cray-opa-ingressgateway-customer-user restarted
ncn-m001:/tmp # kubectl -n opa logs --tail=-1 --prefix=true -l "app.kubernetes.io/name=cray-opa-ingressgateway" | grep -A 1 request_uri
ncn-m001:/tmp # kubectl -n opa logs --tail=-1 --prefix=true -l "app.kubernetes.io/name=cray-opa-ingressgateway-customer-user" | grep -A 1 request_uri
```

Running exploit for NMN:

```ncn-m001:/tmp # ./netcat  -n -v -l -p 4444
Connection from 10.38.3.92:36216
GET / HTTP/1.1
Host: 10.36.0.0:4444
Connection: Keep-Alive
User-Agent: Apache-HttpClient/4.5.4 (Java/11.0.16.1)
Accept-Encoding: gzip,deflate

^CExiting.

ncn-m001:/tmp # python ./test.py -u https://api-gw-service-nmn.local

[+] Keycloak Bind SSRF test by ColdFusionX

[^] Input Netcat host:port -> 10.36.0.0:4444
/usr/lib/python3.6/site-packages/urllib3/connectionpool.py:988: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api-gw-service-nmn.local'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
<Response [400]>

[+] BINGO! Check Netcat listener for HTTP callback :)
```

OPA Debug Logs showing access allowed:

```ncn-m001:/tmp # kubectl -n opa logs --tail=-1 --prefix=true -l "app.kubernetes.io/name=cray-opa-ingressgateway" | grep -A 1 request_uri
[pod/cray-opa-ingressgateway-c698995df-768mj/opa-istio] {"dry-run":false,"input":[[{"type":"string","value":"parsed_query"},{"type":"object","value":[[{"type":"string","value":"response_type"},{"type":"array","value":[{"type":"string","value":"code"}]}],[{"type":"string","value":"redirect_uri"},{"type":"array","value":[{"type":"string","value":"valid"}]}],[{"type":"string","value":"state"},{"type":"array","value":[{"type":"string","value":"cfx"}]}],[{"type":"string","value":"nonce"},{"type":"array","value":[{"type":"string","value":"cfx"}]}],[{"type":"string","value":"client_id"},{"type":"array","value":[{"type":"string","value":"security-admin-console"}]}],[{"type":"string","value":"request_uri"},{"type":"array","value":[{"type":"string","value":http://10.36.0.0:4444}]}],[{"type":"string","value":"scope"},{"type":"array","value":[{"type":"string","value":"openid"}]}]]}],[{"type":"string","value":"parsed_body"},{"type":"null","value":{}}],[{"type":"string","value":"truncated_body"},{"type":"boolean","value":false}],[{"type":"string","value":"attributes"},{"type":"object","value":[[{"type":"string","value":"source"},{"type":"object","value":[[{"type":"string","value":"address"},{"type":"object","value":[[{"type":"string","value":"Address"},{"type":"object","value":[[{"type":"string","value":"SocketAddress"},{"type":"object","value":[[{"type":"string","value":"address"},{"type":"string","value":"10.36.0.0"}],[{"type":"string","value":"PortSpecifier"},{"type":"object","value":[[{"type":"string","value":"PortValue"},{"type":"number","value":12257}]]}]]}]]}]]}]]}],[{"type":"string","value":"destination"},{"type":"object","value":[[{"type":"string","value":"address"},{"type":"object","value":[[{"type":"string","value":"Address"},{"type":"object","value":[[{"type":"string","value":"SocketAddress"},{"type":"object","value":[[{"type":"string","value":"address"},{"type":"string","value":"10.42.0.71"}],[{"type":"string","value":"PortSpecifier"},{"type":"object","value":[[{"type":"string","value":"PortValue"},{"type":"number","value":443}]]}]]}]]}]]}],[{"type":"string","value":"principal"},{"type":"string","value":"*.can.drax.dev.cray.com"}]]}],[{"type":"string","value":"request"},{"type":"object","value":[[{"type":"string","value":"time"},{"type":"object","value":[[{"type":"string","value":"seconds"},{"type":"number","value":1667881214}],[{"type":"string","value":"nanos"},{"type":"number","value":114458000}]]}],[{"type":"string","value":"http"},{"type":"object","value":[[{"type":"string","value":"host"},{"type":"string","value":"api-gw-service-nmn.local"}],[{"type":"string","value":"protocol"},{"type":"string","value":"HTTP/1.1"}],[{"type":"string","value":"id"},{"type":"string","value":"8440006953772269319"}],[{"type":"string","value":"method"},{"type":"string","value":"GET"}],[{"type":"string","value":"headers"},{"type":"object","value":[[{"type":"string","value":"x-envoy-decorator-operation"},{"type":"string","value":"cray-keycloak-http.services.svc.cluster.local:80/keycloak*"}],[{"type":"string","value":"x-envoy-internal"},{"type":"string","value":"true"}],[{"type":"string","value":"x-envoy-peer-metadata-id"},{"type":"string","value":"router~10.42.0.71~istio-ingressgateway-6467b544f8-zpxlw.istio-system~istio-system.svc.cluster.local"}],[{"type":"string","value":"x-request-id"},{"type":"string","value":"658ed2e7-736f-471d-a9c9-f33a3a26f39e"}],[{"type":"string","value":":path"},{"type":"string","value":"/keycloak/realms/master/protocol/openid-connect/auth?scope=openid\u0026response_type=code\u0026redirect_uri=valid\u0026state=cfx\u0026nonce=cfx\u0026client_id=security-admin-console\u0026request_uri=http://10.36.0.0:4444"}],[{"type":"string","value":"accept"},{"type":"string","value":"*/*"}],[{"type":"string","value":"accept-encoding"},{"type":"string","value":"gzip, deflate"}],[{"type":"string","value":"user-agent"},{"type":"string","value":"Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0"}],[{"type":"string","value":"x-envoy-peer-metadata"},{"type":"string","value":"ChQKDkFQUF9DT05UQUlORVJTEgIaAAoaCgpDTFVTVEVSX0lEEgwaCkt1YmVybmV0ZXMKGAoNSVNUSU9fVkVSU0lPThIHGgUxLjguNgqAAgoGTEFCRUxTEvUBKvIBCh0KA2FwcBIWGhRpc3Rpby1pbmdyZXNzZ2F0ZXdheQoTCgVjaGFydBIKGghnYXRld2F5cwoZCgVpc3RpbxIQGg5pbmdyZXNzZ2F0ZXdheQohChFwb2QtdGVtcGxhdGUtaGFzaBIMGgo2NDY3YjU0NGY4ChIKB3JlbGVhc2USBxoFaXN0aW8KOQofc2VydmljZS5pc3Rpby5pby9jYW5vbmljYWwtbmFtZRIWGhRpc3Rpby1pbmdyZXNzZ2F0ZXdheQovCiNzZXJ2aWNlLmlzdGlvLmlvL2Nhbm9uaWNhbC1yZXZpc2lvbhIIGgZsYXRlc3QKGgoHTUVTSF9JRBIPGg1jbHVzdGVyLmxvY2FsCi8KBE5BTUUSJxolaXN0aW8taW5ncmVzc2dhdGV3YXktNjQ2N2I1NDRmOC16cHhsdwobCglOQU1FU1BBQ0USDhoMaXN0aW8tc3lzdGVtCl0KBU9XTkVSElQaUmt1YmVybmV0ZXM6Ly9hcGlzL2FwcHMvdjEvbmFtZXNwYWNlcy9pc3Rpby1zeXN0ZW0vZGVwbG95bWVudHMvaXN0aW8taW5ncmVzc2dhdGV3YXkKFwoRUExBVEZPUk1fTUVUQURBVEESAioACicKDVdPUktMT0FEX05BTUUSFhoUaXN0aW8taW5ncmVzc2dhdGV3YXk="}],[{"type":"string","value":"x-forwarded-for"},{"type":"string","value":"10.36.0.0"}],[{"type":"string","value":"x-forwarded-proto"},{"type":"string","value":"https"}],[{"type":"string","value":":authority"},{"type":"string","value":"api-gw-service-nmn.local"}],[{"type":"string","value":":method"},{"type":"string","value":"GET"}]]}],[{"type":"string","value":"path"},{"type":"string","value":"/keycloak/realms/master/protocol/openid-connect/auth?scope=openid\u0026response_type=code\u0026redirect_uri=valid\u0026state=cfx\u0026nonce=cfx\u0026client_id=security-admin-console\u0026request_uri=http://10.36.0.0:4444"}]]}]]}],[{"type":"string","value":"metadata_context"},{"type":"object","value":[]}]]}],[{"type":"string","value":"parsed_path"},{"type":"array","value":[{"type":"string","value":"keycloak"},{"type":"string","value":"realms"},{"type":"string","value":"master"},{"type":"string","value":"protocol"},{"type":"string","value":"openid-connect"},{"type":"string","value":"auth"}]}]],"level":"debug","msg":"Executing policy query.","query":"data.istio.authz.allow","time":"2022-11-08T04:20:14Z","txn":206}

[pod/cray-opa-ingressgateway-c698995df-768mj/opa-istio] {"decision":true,"dry-run":false,"err":null,"level":"debug","metrics":{"timer_rego_query_eval_ns":366497,"timer_server_handler_ns":0},"msg":"Returning policy decision.","query":"data.istio.authz.allow","time":"2022-11-08T04:20:14Z","total_decision_time":2047125,"txn":206}
```

Running exploit for CAN:

```ncn-m001:/tmp # ./netcat  -n -v -l -p 4444
Connection from 10.38.3.92:48850
GET / HTTP/1.1
Host: 10.36.0.0:4444
Connection: Keep-Alive
User-Agent: Apache-HttpClient/4.5.4 (Java/11.0.16.1)
Accept-Encoding: gzip,deflate

^CExiting.
ncn-m001:/tmp #


ncn-m001:/tmp # python ./test.py -u https://api.can.drax.dev.cray.com

[+] Keycloak Bind SSRF test by ColdFusionX

[^] Input Netcat host:port -> 10.36.0.0:4444
/usr/lib/python3.6/site-packages/urllib3/connectionpool.py:988: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.can.drax.dev.cray.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
<Response [400]>

[+] BINGO! Check Netcat listener for HTTP callback :)
```

OPA Debug Logs showing access denied:

```ncn-m001:/tmp # kubectl -n opa logs --tail=-1 --prefix=true -l "app.kubernetes.io/name=cray-opa-ingressgateway-customer-user" | grep -A 1 request_uri
[pod/cray-opa-ingressgateway-customer-user-59b857bdb8-zmkfn/opa-istio] {"dry-run":false,"input":[[{"type":"string","value":"truncated_body"},{"type":"boolean","value":false}],[{"type":"string","value":"attributes"},{"type":"object","value":[[{"type":"string","value":"source"},{"type":"object","value":[[{"type":"string","value":"address"},{"type":"object","value":[[{"type":"string","value":"Address"},{"type":"object","value":[[{"type":"string","value":"SocketAddress"},{"type":"object","value":[[{"type":"string","value":"address"},{"type":"string","value":"10.36.0.0"}],[{"type":"string","value":"PortSpecifier"},{"type":"object","value":[[{"type":"string","value":"PortValue"},{"type":"number","value":15721}]]}]]}]]}]]}]]}],[{"type":"string","value":"destination"},{"type":"object","value":[[{"type":"string","value":"address"},{"type":"object","value":[[{"type":"string","value":"Address"},{"type":"object","value":[[{"type":"string","value":"SocketAddress"},{"type":"object","value":[[{"type":"string","value":"address"},{"type":"string","value":"10.42.0.63"}],[{"type":"string","value":"PortSpecifier"},{"type":"object","value":[[{"type":"string","value":"PortValue"},{"type":"number","value":443}]]}]]}]]}]]}],[{"type":"string","value":"principal"},{"type":"string","value":"*.can.drax.dev.cray.com"}]]}],[{"type":"string","value":"request"},{"type":"object","value":[[{"type":"string","value":"time"},{"type":"object","value":[[{"type":"string","value":"seconds"},{"type":"number","value":1667881358}],[{"type":"string","value":"nanos"},{"type":"number","value":644886000}]]}],[{"type":"string","value":"http"},{"type":"object","value":[[{"type":"string","value":"path"},{"type":"string","value":"/keycloak/realms/master/protocol/openid-connect/auth?scope=openid\u0026response_type=code\u0026redirect_uri=valid\u0026state=cfx\u0026nonce=cfx\u0026client_id=security-admin-console\u0026request_uri=http://10.36.0.0:4444"}],[{"type":"string","value":"host"},{"type":"string","value":"api.can.drax.dev.cray.com"}],[{"type":"string","value":"protocol"},{"type":"string","value":"HTTP/1.1"}],[{"type":"string","value":"id"},{"type":"string","value":"12545597302654544238"}],[{"type":"string","value":"method"},{"type":"string","value":"GET"}],[{"type":"string","value":"headers"},{"type":"object","value":[[{"type":"string","value":"accept-encoding"},{"type":"string","value":"gzip, deflate"}],[{"type":"string","value":"user-agent"},{"type":"string","value":"Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0"}],[{"type":"string","value":"x-envoy-internal"},{"type":"string","value":"true"}],[{"type":"string","value":"x-envoy-peer-metadata"},{"type":"string","value":"ChQKDkFQUF9DT05UQUlORVJTEgIaAAoaCgpDTFVTVEVSX0lEEgwaCkt1YmVybmV0ZXMKGAoNSVNUSU9fVkVSU0lPThIHGgUxLjguNgqqAgoGTEFCRUxTEp8CKpwCCisKA2FwcBIkGiJpc3Rpby1pbmdyZXNzZ2F0ZXdheS1jdXN0b21lci11c2VyChMKBWNoYXJ0EgoaCGdhdGV3YXlzCicKBWlzdGlvEh4aHGluZ3Jlc3NnYXRld2F5LWN1c3RvbWVyLXVzZXIKIQoRcG9kLXRlbXBsYXRlLWhhc2gSDBoKNmY3ZDg0ZmM4NwoSCgdyZWxlYXNlEgcaBWlzdGlvCkcKH3NlcnZpY2UuaXN0aW8uaW8vY2Fub25pY2FsLW5hbWUSJBoiaXN0aW8taW5ncmVzc2dhdGV3YXktY3VzdG9tZXItdXNlcgovCiNzZXJ2aWNlLmlzdGlvLmlvL2Nhbm9uaWNhbC1yZXZpc2lvbhIIGgZsYXRlc3QKGgoHTUVTSF9JRBIPGg1jbHVzdGVyLmxvY2FsCj0KBE5BTUUSNRozaXN0aW8taW5ncmVzc2dhdGV3YXktY3VzdG9tZXItdXNlci02ZjdkODRmYzg3LTdia3pnChsKCU5BTUVTUEFDRRIOGgxpc3Rpby1zeXN0ZW0KawoFT1dORVISYhpga3ViZXJuZXRlczovL2FwaXMvYXBwcy92MS9uYW1lc3BhY2VzL2lzdGlvLXN5c3RlbS9kZXBsb3ltZW50cy9pc3Rpby1pbmdyZXNzZ2F0ZXdheS1jdXN0b21lci11c2VyChcKEVBMQVRGT1JNX01FVEFEQVRBEgIqAAo1Cg1XT1JLTE9BRF9OQU1FEiQaImlzdGlvLWluZ3Jlc3NnYXRld2F5LWN1c3RvbWVyLXVzZXI="}],[{"type":"string","value":":authority"},{"type":"string","value":"api.can.drax.dev.cray.com"}],[{"type":"string","value":":method"},{"type":"string","value":"GET"}],[{"type":"string","value":":path"},{"type":"string","value":"/keycloak/realms/master/protocol/openid-connect/auth?scope=openid\u0026response_type=code\u0026redirect_uri=valid\u0026state=cfx\u0026nonce=cfx\u0026client_id=security-admin-console\u0026request_uri=http://10.36.0.0:4444"}],[{"type":"string","value":"accept"},{"type":"string","value":"*/*"}],[{"type":"string","value":"x-forwarded-for"},{"type":"string","value":"10.36.0.0"}],[{"type":"string","value":"x-forwarded-proto"},{"type":"string","value":"https"}],[{"type":"string","value":"x-request-id"},{"type":"string","value":"7fffcfd4-5492-4249-9722-ad6d0fbc00fe"}],[{"type":"string","value":"x-envoy-decorator-operation"},{"type":"string","value":"cray-keycloak-http.services.svc.cluster.local:80/keycloak*"}],[{"type":"string","value":"x-envoy-peer-metadata-id"},{"type":"string","value":"router~10.42.0.63~istio-ingressgateway-customer-user-6f7d84fc87-7bkzg.istio-system~istio-system.svc.cluster.local"}]]}]]}]]}],[{"type":"string","value":"metadata_context"},{"type":"object","value":[]}]]}],[{"type":"string","value":"parsed_path"},{"type":"array","value":[{"type":"string","value":"keycloak"},{"type":"string","value":"realms"},{"type":"string","value":"master"},{"type":"string","value":"protocol"},{"type":"string","value":"openid-connect"},{"type":"string","value":"auth"}]}],[{"type":"string","value":"parsed_query"},{"type":"object","value":[[{"type":"string","value":"redirect_uri"},{"type":"array","value":[{"type":"string","value":"valid"}]}],[{"type":"string","value":"state"},{"type":"array","value":[{"type":"string","value":"cfx"}]}],[{"type":"string","value":"nonce"},{"type":"array","value":[{"type":"string","value":"cfx"}]}],[{"type":"string","value":"client_id"},{"type":"array","value":[{"type":"string","value":"security-admin-console"}]}],[{"type":"string","value":"request_uri"},{"type":"array","value":[{"type":"string","value":http://10.36.0.0:4444}]}],[{"type":"string","value":"scope"},{"type":"array","value":[{"type":"string","value":"openid"}]}],[{"type":"string","value":"response_type"},{"type":"array","value":[{"type":"string","value":"code"}]}]]}],[{"type":"string","value":"parsed_body"},{"type":"null","value":{}}]],"level":"debug","msg":"Executing policy query.","query":"data.istio.authz.allow","time":"2022-11-08T04:22:38Z","txn":3}

[pod/cray-opa-ingressgateway-customer-user-59b857bdb8-zmkfn/opa-istio] {"decision":true,"dry-run":false,"err":null,"level":"debug","metrics":{"timer_rego_query_compile_ns":124442,"timer_rego_query_eval_ns":200653,"timer_server_handler_ns":0},"msg":"Returning policy decision.","query":"data.istio.authz.allow","time":"2022-11-08T04:22:38Z","total_decision_time":2515497,"txn":3}
```

### After Policy Modification

Execution of updated OPA test suite.

```SUMMARY
--------------------------------------------------------------------------------
data.istio.authz.test_allow_bypassed_urls_with_no_auth_header: PASS (5.977304ms)
data.istio.authz.test_deny_tokens_endpoint: PASS (772.488µs)
data.istio.authz.test_deny_apis_with_no_auth_header: PASS (785.349µs)
data.istio.authz.test_user_when_admin_required: PASS (4.498347ms)
data.istio.authz.test_user: PASS (5.136984ms)
data.istio.authz.test_admin: PASS (2.920261ms)
data.istio.authz.test_pxe: PASS (4.927982ms)
data.istio.authz.test_compute: FAIL (12.228779ms)
data.istio.authz.test_wlm: PASS (136.268599ms)
data.istio.authz.test_unauth_role: PASS (2.637308ms)
data.istio.authz.test_spire_subs: FAIL (4.567808ms)
data.istio.authz.test_spire_ckdump: PASS (70.15665ms)
data.istio.authz.test_spire_invalid_sub: PASS (35.202021ms)
data.istio.authz.test_nexus: PASS (760.908µs)
--------------------------------------------------------------------------------
```

After implementing the fix:

Fix:

```
    allow {
        startswith(original_path, "/keycloak")
        not re_match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
    }
```

```ncn-m001:/tmp # kubectl get cm -n opa
NAME                                         DATA   AGE
cray-configmap-ca-public-key                 3      19d
istio-ca-root-cert                           1      19d
istio-config-ingressgateway                  1      4d15h
istio-config-ingressgateway-customer-admin   1      4d15h
istio-config-ingressgateway-customer-user    1      4d15h
kube-root-ca.crt                             1      4d16h
opa-policy-ingressgateway                    1      4d15h
opa-policy-ingressgateway-customer-admin     1      4d15h
opa-policy-ingressgateway-customer-user      1      4d15h
ncn-m001:/tmp # kubectl edit cm opa-policy-ingressgateway -n opa
configmap/opa-policy-ingressgateway edited
ncn-m001:/tmp #
```

Running exploit for NMN (note HTTP 403 response):

```ncn-m001:/tmp # ./netcat -n -v -l -p 4444

ncn-m001:/tmp # python ./test.py -u https://api-gw-service-nmn.local

[+] Keycloak Bind SSRF test by ColdFusionX

[^] Input Netcat host:port -> 10.36.0.0:4444
/usr/lib/python3.6/site-packages/urllib3/connectionpool.py:988: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api-gw-service-nmn.local'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
<Response [403]>

[+] BINGO! Check Netcat listener for HTTP callback :)
```

OPA Debug logs showing access denied:

```ncn-m001:/tmp # kubectl -n opa logs --tail=-1 --prefix=true -l "app.kubernetes.io/name=cray-opa-ingressgateway" | grep -A 1 request_uri
[pod/cray-opa-ingressgateway-bc7b688f5-lq7nc/opa-istio] {"dry-run":false,"input":[[{"type":"string","value":"parsed_body"},{"type":"null","value":{}}],[{"type":"string","value":"truncated_body"},{"type":"boolean","value":false}],[{"type":"string","value":"attributes"},{"type":"object","value":[[{"type":"string","value":"request"},{"type":"object","value":[[{"type":"string","value":"time"},{"type":"object","value":[[{"type":"string","value":"seconds"},{"type":"number","value":1667888146}],[{"type":"string","value":"nanos"},{"type":"number","value":360563000}]]}],[{"type":"string","value":"http"},{"type":"object","value":[[{"type":"string","value":"headers"},{"type":"object","value":[[{"type":"string","value":"accept-encoding"},{"type":"string","value":"gzip, deflate"}],[{"type":"string","value":"user-agent"},{"type":"string","value":"Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0"}],[{"type":"string","value":"x-envoy-internal"},{"type":"string","value":"true"}],[{"type":"string","value":"x-envoy-peer-metadata"},{"type":"string","value":"ChQKDkFQUF9DT05UQUlORVJTEgIaAAoaCgpDTFVTVEVSX0lEEgwaCkt1YmVybmV0ZXMKGAoNSVNUSU9fVkVSU0lPThIHGgUxLjguNgqAAgoGTEFCRUxTEvUBKvIBCh0KA2FwcBIWGhRpc3Rpby1pbmdyZXNzZ2F0ZXdheQoTCgVjaGFydBIKGghnYXRld2F5cwoZCgVpc3RpbxIQGg5pbmdyZXNzZ2F0ZXdheQohChFwb2QtdGVtcGxhdGUtaGFzaBIMGgo2NDY3YjU0NGY4ChIKB3JlbGVhc2USBxoFaXN0aW8KOQofc2VydmljZS5pc3Rpby5pby9jYW5vbmljYWwtbmFtZRIWGhRpc3Rpby1pbmdyZXNzZ2F0ZXdheQovCiNzZXJ2aWNlLmlzdGlvLmlvL2Nhbm9uaWNhbC1yZXZpc2lvbhIIGgZsYXRlc3QKGgoHTUVTSF9JRBIPGg1jbHVzdGVyLmxvY2FsCi8KBE5BTUUSJxolaXN0aW8taW5ncmVzc2dhdGV3YXktNjQ2N2I1NDRmOC16cHhsdwobCglOQU1FU1BBQ0USDhoMaXN0aW8tc3lzdGVtCl0KBU9XTkVSElQaUmt1YmVybmV0ZXM6Ly9hcGlzL2FwcHMvdjEvbmFtZXNwYWNlcy9pc3Rpby1zeXN0ZW0vZGVwbG95bWVudHMvaXN0aW8taW5ncmVzc2dhdGV3YXkKFwoRUExBVEZPUk1fTUVUQURBVEESAioACicKDVdPUktMT0FEX05BTUUSFhoUaXN0aW8taW5ncmVzc2dhdGV3YXk="}],[{"type":"string","value":"x-forwarded-proto"},{"type":"string","value":"https"}],[{"type":"string","value":"x-request-id"},{"type":"string","value":"b40b712d-df31-4a30-9fbc-351ea4b2d93b"}],[{"type":"string","value":"accept"},{"type":"string","value":"*/*"}],[{"type":"string","value":":method"},{"type":"string","value":"GET"}],[{"type":"string","value":":path"},{"type":"string","value":"/keycloak/realms/master/protocol/openid-connect/auth?scope=openid\u0026response_type=code\u0026redirect_uri=valid\u0026state=cfx\u0026nonce=cfx\u0026client_id=security-admin-console\u0026request_uri=http://10.36.0.0:4444"}],[{"type":"string","value":"x-envoy-decorator-operation"},{"type":"string","value":"cray-keycloak-http.services.svc.cluster.local:80/keycloak*"}],[{"type":"string","value":"x-envoy-peer-metadata-id"},{"type":"string","value":"router~10.42.0.71~istio-ingressgateway-6467b544f8-zpxlw.istio-system~istio-system.svc.cluster.local"}],[{"type":"string","value":"x-forwarded-for"},{"type":"string","value":"10.36.0.0"}],[{"type":"string","value":":authority"},{"type":"string","value":"api-gw-service-nmn.local"}]]}],[{"type":"string","value":"path"},{"type":"string","value":"/keycloak/realms/master/protocol/openid-connect/auth?scope=openid\u0026response_type=code\u0026redirect_uri=valid\u0026state=cfx\u0026nonce=cfx\u0026client_id=security-admin-console\u0026request_uri=http://10.36.0.0:4444"}],[{"type":"string","value":"host"},{"type":"string","value":"api-gw-service-nmn.local"}],[{"type":"string","value":"protocol"},{"type":"string","value":"HTTP/1.1"}],[{"type":"string","value":"id"},{"type":"string","value":"3155017386182227035"}],[{"type":"string","value":"method"},{"type":"string","value":"GET"}]]}]]}],[{"type":"string","value":"metadata_context"},{"type":"object","value":[]}],[{"type":"string","value":"source"},{"type":"object","value":[[{"type":"string","value":"address"},{"type":"object","value":[[{"type":"string","value":"Address"},{"type":"object","value":[[{"type":"string","value":"SocketAddress"},{"type":"object","value":[[{"type":"string","value":"address"},{"type":"string","value":"10.36.0.0"}],[{"type":"string","value":"PortSpecifier"},{"type":"object","value":[[{"type":"string","value":"PortValue"},{"type":"number","value":1488}]]}]]}]]}]]}]]}],[{"type":"string","value":"destination"},{"type":"object","value":[[{"type":"string","value":"address"},{"type":"object","value":[[{"type":"string","value":"Address"},{"type":"object","value":[[{"type":"string","value":"SocketAddress"},{"type":"object","value":[[{"type":"string","value":"address"},{"type":"string","value":"10.42.0.71"}],[{"type":"string","value":"PortSpecifier"},{"type":"object","value":[[{"type":"string","value":"PortValue"},{"type":"number","value":443}]]}]]}]]}]]}],[{"type":"string","value":"principal"},{"type":"string","value":"*.can.drax.dev.cray.com"}]]}]]}],[{"type":"string","value":"parsed_path"},{"type":"array","value":[{"type":"string","value":"keycloak"},{"type":"string","value":"realms"},{"type":"string","value":"master"},{"type":"string","value":"protocol"},{"type":"string","value":"openid-connect"},{"type":"string","value":"auth"}]}],[{"type":"string","value":"parsed_query"},{"type":"object","value":[[{"type":"string","value":"redirect_uri"},{"type":"array","value":[{"type":"string","value":"valid"}]}],[{"type":"string","value":"state"},{"type":"array","value":[{"type":"string","value":"cfx"}]}],[{"type":"string","value":"nonce"},{"type":"array","value":[{"type":"string","value":"cfx"}]}],[{"type":"string","value":"client_id"},{"type":"array","value":[{"type":"string","value":"security-admin-console"}]}],[{"type":"string","value":"request_uri"},{"type":"array","value":[{"type":"string","value":http://10.36.0.0:4444}]}],[{"type":"string","value":"scope"},{"type":"array","value":[{"type":"string","value":"openid"}]}],[{"type":"string","value":"response_type"},{"type":"array","value":[{"type":"string","value":"code"}]}]]}]],"level":"debug","msg":"Executing policy query.","query":"data.istio.authz.allow","time":"2022-11-08T06:15:46Z","txn":57}

[pod/cray-opa-ingressgateway-bc7b688f5-lq7nc/opa-istio] {"decision":{"allowed":false,"body":"Unauthorized Request","headers":{"x-ext-auth-allow":"no"},"http_status":403},"dry-run":false,"err":null,"level":"debug","metrics":{"timer_rego_query_eval_ns":355176,"timer_server_handler_ns":0},"msg":"Returning policy decision.","query":"data.istio.authz.allow","time":"2022-11-08T06:15:46Z","total_decision_time":1953203,"txn":57}
```

Running exploit for CAN:

```ncn-m001:/tmp # kubectl edit cm opa-policy-ingressgateway-customer-user -n opa
configmap/opa-policy-ingressgateway-customer-user edited
ncn-m001:/tmp #
ncn-m001:/tmp # kubectl rollout restart -n opa deployment cray-opa-ingressgateway-customer-user
deployment.apps/cray-opa-ingressgateway-customer-user restarted
ncn-m001:/tmp #
ncn-m001:/tmp # kubectl get pods -n opa
NAME                                                      READY   STATUS    RESTARTS   AGE
cray-opa-ingressgateway-bc7b688f5-jkfbg                   1/1     Running   0          6m20s
cray-opa-ingressgateway-bc7b688f5-lq7nc                   1/1     Running   0          6m21s
cray-opa-ingressgateway-bc7b688f5-sdn4h                   1/1     Running   0          6m20s
cray-opa-ingressgateway-customer-admin-5c5684cc8c-fd9gr   1/1     Running   0          4d17h
cray-opa-ingressgateway-customer-admin-5c5684cc8c-jz6bz   1/1     Running   0          4d17h
cray-opa-ingressgateway-customer-admin-5c5684cc8c-z4tlr   1/1     Running   0          4d17h
cray-opa-ingressgateway-customer-user-65d978dd7d-9k2t7    1/1     Running   0          49s
cray-opa-ingressgateway-customer-user-65d978dd7d-pc84v    1/1     Running   0          49s
cray-opa-ingressgateway-customer-user-65d978dd7d-vjwvr    1/1     Running   0          49s
ncn-m001:/tmp #

ncn-m001:/tmp # ./netcat -n -v -l -p 4444

ncn-m001:/tmp # python ./test.py -u https://api.can.drax.dev.cray.com

[+] Keycloak Bind SSRF test by ColdFusionX

[^] Input Netcat host:port -> 10.36.0.0:4444
/usr/lib/python3.6/site-packages/urllib3/connectionpool.py:988: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.can.drax.dev.cray.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
<Response [403]>

[+] BINGO! Check Netcat listener for HTTP callback :)
```

OPA Debug logs showing access denied:

```ncn-m001:/tmp # kubectl -n opa logs --tail=-1 --prefix=true -l "app.kubernetes.io/name=cray-opa-ingressgateway-customer-user" | grep -A 1 request_uri
[pod/cray-opa-ingressgateway-customer-user-65d978dd7d-vjwvr/opa-istio] {"dry-run":false,"input":[[{"type":"string","value":"attributes"},{"type":"object","value":[[{"type":"string","value":"source"},{"type":"object","value":[[{"type":"string","value":"address"},{"type":"object","value":[[{"type":"string","value":"Address"},{"type":"object","value":[[{"type":"string","value":"SocketAddress"},{"type":"object","value":[[{"type":"string","value":"PortSpecifier"},{"type":"object","value":[[{"type":"string","value":"PortValue"},{"type":"number","value":24942}]]}],[{"type":"string","value":"address"},{"type":"string","value":"10.36.0.0"}]]}]]}]]}]]}],[{"type":"string","value":"destination"},{"type":"object","value":[[{"type":"string","value":"principal"},{"type":"string","value":"*.can.drax.dev.cray.com"}],[{"type":"string","value":"address"},{"type":"object","value":[[{"type":"string","value":"Address"},{"type":"object","value":[[{"type":"string","value":"SocketAddress"},{"type":"object","value":[[{"type":"string","value":"address"},{"type":"string","value":"10.42.0.10"}],[{"type":"string","value":"PortSpecifier"},{"type":"object","value":[[{"type":"string","value":"PortValue"},{"type":"number","value":443}]]}]]}]]}]]}]]}],[{"type":"string","value":"request"},{"type":"object","value":[[{"type":"string","value":"time"},{"type":"object","value":[[{"type":"string","value":"seconds"},{"type":"number","value":1667888532}],[{"type":"string","value":"nanos"},{"type":"number","value":301949000}]]}],[{"type":"string","value":"http"},{"type":"object","value":[[{"type":"string","value":"method"},{"type":"string","value":"GET"}],[{"type":"string","value":"headers"},{"type":"object","value":[[{"type":"string","value":"x-forwarded-for"},{"type":"string","value":"10.36.0.0"}],[{"type":"string","value":"x-forwarded-proto"},{"type":"string","value":"https"}],[{"type":"string","value":"x-request-id"},{"type":"string","value":"39bfee94-4083-4e18-af3c-2ebc7b45639c"}],[{"type":"string","value":":path"},{"type":"string","value":"/keycloak/realms/master/protocol/openid-connect/auth?scope=openid\u0026response_type=code\u0026redirect_uri=valid\u0026state=cfx\u0026nonce=cfx\u0026client_id=security-admin-console\u0026request_uri=http://10.36.0.0:4444"}],[{"type":"string","value":"accept-encoding"},{"type":"string","value":"gzip, deflate"}],[{"type":"string","value":"user-agent"},{"type":"string","value":"Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0"}],[{"type":"string","value":"x-envoy-internal"},{"type":"string","value":"true"}],[{"type":"string","value":"x-envoy-peer-metadata"},{"type":"string","value":"ChQKDkFQUF9DT05UQUlORVJTEgIaAAoaCgpDTFVTVEVSX0lEEgwaCkt1YmVybmV0ZXMKGAoNSVNUSU9fVkVSU0lPThIHGgUxLjguNgqqAgoGTEFCRUxTEp8CKpwCCisKA2FwcBIkGiJpc3Rpby1pbmdyZXNzZ2F0ZXdheS1jdXN0b21lci11c2VyChMKBWNoYXJ0EgoaCGdhdGV3YXlzCicKBWlzdGlvEh4aHGluZ3Jlc3NnYXRld2F5LWN1c3RvbWVyLXVzZXIKIQoRcG9kLXRlbXBsYXRlLWhhc2gSDBoKNmY3ZDg0ZmM4NwoSCgdyZWxlYXNlEgcaBWlzdGlvCkcKH3NlcnZpY2UuaXN0aW8uaW8vY2Fub25pY2FsLW5hbWUSJBoiaXN0aW8taW5ncmVzc2dhdGV3YXktY3VzdG9tZXItdXNlcgovCiNzZXJ2aWNlLmlzdGlvLmlvL2Nhbm9uaWNhbC1yZXZpc2lvbhIIGgZsYXRlc3QKGgoHTUVTSF9JRBIPGg1jbHVzdGVyLmxvY2FsCj0KBE5BTUUSNRozaXN0aW8taW5ncmVzc2dhdGV3YXktY3VzdG9tZXItdXNlci02ZjdkODRmYzg3LTRqZzhqChsKCU5BTUVTUEFDRRIOGgxpc3Rpby1zeXN0ZW0KawoFT1dORVISYhpga3ViZXJuZXRlczovL2FwaXMvYXBwcy92MS9uYW1lc3BhY2VzL2lzdGlvLXN5c3RlbS9kZXBsb3ltZW50cy9pc3Rpby1pbmdyZXNzZ2F0ZXdheS1jdXN0b21lci11c2VyChcKEVBMQVRGT1JNX01FVEFEQVRBEgIqAAo1Cg1XT1JLTE9BRF9OQU1FEiQaImlzdGlvLWluZ3Jlc3NnYXRld2F5LWN1c3RvbWVyLXVzZXI="}],[{"type":"string","value":":authority"},{"type":"string","value":"api.can.drax.dev.cray.com"}],[{"type":"string","value":":method"},{"type":"string","value":"GET"}],[{"type":"string","value":"accept"},{"type":"string","value":"*/*"}],[{"type":"string","value":"x-envoy-decorator-operation"},{"type":"string","value":"cray-keycloak-http.services.svc.cluster.local:80/keycloak*"}],[{"type":"string","value":"x-envoy-peer-metadata-id"},{"type":"string","value":"router~10.42.0.10~istio-ingressgateway-customer-user-6f7d84fc87-4jg8j.istio-system~istio-system.svc.cluster.local"}]]}],[{"type":"string","value":"path"},{"type":"string","value":"/keycloak/realms/master/protocol/openid-connect/auth?scope=openid\u0026response_type=code\u0026redirect_uri=valid\u0026state=cfx\u0026nonce=cfx\u0026client_id=security-admin-console\u0026request_uri=http://10.36.0.0:4444"}],[{"type":"string","value":"host"},{"type":"string","value":"api.can.drax.dev.cray.com"}],[{"type":"string","value":"protocol"},{"type":"string","value":"HTTP/1.1"}],[{"type":"string","value":"id"},{"type":"string","value":"12595293227309378430"}]]}]]}],[{"type":"string","value":"metadata_context"},{"type":"object","value":[]}]]}],[{"type":"string","value":"parsed_path"},{"type":"array","value":[{"type":"string","value":"keycloak"},{"type":"string","value":"realms"},{"type":"string","value":"master"},{"type":"string","value":"protocol"},{"type":"string","value":"openid-connect"},{"type":"string","value":"auth"}]}],[{"type":"string","value":"parsed_query"},{"type":"object","value":[[{"type":"string","value":"state"},{"type":"array","value":[{"type":"string","value":"cfx"}]}],[{"type":"string","value":"nonce"},{"type":"array","value":[{"type":"string","value":"cfx"}]}],[{"type":"string","value":"client_id"},{"type":"array","value":[{"type":"string","value":"security-admin-console"}]}],[{"type":"string","value":"request_uri"},{"type":"array","value":[{"type":"string","value":http://10.36.0.0:4444}]}],[{"type":"string","value":"scope"},{"type":"array","value":[{"type":"string","value":"openid"}]}],[{"type":"string","value":"response_type"},{"type":"array","value":[{"type":"string","value":"code"}]}],[{"type":"string","value":"redirect_uri"},{"type":"array","value":[{"type":"string","value":"valid"}]}]]}],[{"type":"string","value":"parsed_body"},{"type":"null","value":{}}],[{"type":"string","value":"truncated_body"},{"type":"boolean","value":false}]],"level":"debug","msg":"Executing policy query.","query":"data.istio.authz.allow","time":"2022-11-08T06:22:12Z","txn":3}

[pod/cray-opa-ingressgateway-customer-user-65d978dd7d-vjwvr/opa-istio] {"decision":{"allowed":false,"body":"Unauthorized Request","headers":{"x-ext-auth-allow":"no"},"http_status":403},"dry-run":false,"err":null,"level":"debug","metrics":{"timer_rego_query_compile_ns":132172,"timer_rego_query_eval_ns":349796,"timer_server_handler_ns":0},"msg":"Returning policy decision.","query":"data.istio.authz.allow","time":"2022-11-08T06:22:12Z","total_decision_time":2509612,"txn":3}
```

Regression test summary on drax:

```SUMMARY
--------------------------------------------------------------------------------
data.istio.authz.test_allow_bypassed_urls_with_no_auth_header: PASS (5.389257ms)
data.istio.authz.test_deny_tokens_endpoint: PASS (746.048µs)
data.istio.authz.test_deny_apis_with_no_auth_header: PASS (690.787µs)
data.istio.authz.test_user_when_admin_required: PASS (2.8768ms)
data.istio.authz.test_user: PASS (5.353647ms)
data.istio.authz.test_ssrf: PASS (957.92µs)
data.istio.authz.test_admin: PASS (2.967681ms)
data.istio.authz.test_pxe: PASS (7.271696ms)
data.istio.authz.test_compute: FAIL (15.100929ms)
data.istio.authz.test_wlm: PASS (136.873674ms)
data.istio.authz.test_unauth_role: PASS (4.257395ms)
data.istio.authz.test_spire_subs: FAIL (5.380317ms)
data.istio.authz.test_spire_ckdump: PASS (73.836009ms)
data.istio.authz.test_spire_invalid_sub: PASS (32.508592ms)
data.istio.authz.test_nexus: PASS (782.179µs)
--------------------------------------------------------------------------------
```


### Tested on:

DRAX system (CSM 1.2.2 beta 5, upgrade from CSM 1.0.11)

### Test description:

Performed unit testing.
Included the test case in regression and performed testing.
Logs are shared above.

## Risks and Mitigations

The changes are mitigation for CVE.



