### PR TITLE
CASMPET-6136 Update test image paths

### DIFF
--- a/kubernetes/cray-opa/tests/opa/Dockerfile
+++ b/kubernetes/cray-opa/tests/opa/Dockerfile
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-FROM arti.dev.cray.com/baseos-docker-master-local/golang:1.14.9-alpine3.12 AS builder
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/golang:1.17.3-alpine3.15 AS builder
 
 ENV GO111MODULE=on \
     CGO_ENABLED=0 \

--- a/kubernetes/cray-opa/tests/opa/xname-disabled/Dockerfile
+++ b/kubernetes/cray-opa/tests/opa/xname-disabled/Dockerfile
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-FROM arti.dev.cray.com/baseos-docker-master-local/golang:1.14.9-alpine3.12 AS builder
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/golang:1.17.3-alpine3.15 AS builder
 
 ENV GO111MODULE=on \
     CGO_ENABLED=0 \
@@ -35,7 +35,7 @@ RUN cd src/run_tests && go mod download
 RUN cd src/run_tests && go build .
 RUN ls src/run_tests
 
-FROM arti.dev.cray.com/third-party-docker-stable-local/openpolicyagent/opa:0.24.0-envoy-1
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
 
 COPY --from=builder /go/src/run_tests/run_tests .
 COPY tests/opa/certificate_authority.crt /jwtValidationFetchTls/certificate_authority.crt

--- a/kubernetes/cray-opa/tests/opa/xname-enabled/Dockerfile
+++ b/kubernetes/cray-opa/tests/opa/xname-enabled/Dockerfile
@@ -22,12 +22,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-FROM arti.dev.cray.com/baseos-docker-master-local/golang:1.14.9-alpine3.12 AS builder
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/golang:1.17.3-alpine3.15 AS builder
 
 ENV GO111MODULE=on \
     CGO_ENABLED=0 \
-    GOOS=linux \
-    GOARCH=amd64
+   GOOS=linux \
+   GOARCH=amd64
 
 COPY tests/opa/xname-enabled/run_tests src/run_tests
 
@@ -35,7 +35,7 @@ RUN cd src/run_tests && go mod download
 RUN cd src/run_tests && go build .
 RUN ls src/run_tests
 
-FROM arti.dev.cray.com/third-party-docker-stable-local/openpolicyagent/opa:0.24.0-envoy-1
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.24.0-envoy-1
 
 COPY --from=builder /go/src/run_tests/run_tests .
 COPY tests/opa/certificate_authority.crt /jwtValidationFetchTls/certificate_authority.crt


### PR DESCRIPTION
## Summary and Scope

This change updates the docker image paths for the rego tests, allowing them to complete succesfully.

## Issues and Related PRs


* Resolves [CASMPET-6136](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6136) 

## Testing

### Tested on:

  * Local development environment

### Test description:

Validated tests ran successfully

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

