### PR TITLE
CASMPET-6128: Break/Fix - Add opa policies to address keycloak vulnerabilities for request_uri and user access to admin paths

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.25.4
+version: 1.25.5
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
@@ -48,7 +48,10 @@ original_path = o_path {
 #
 #     * VCS/Gitea
 #
-allow { startswith(original_path, "/keycloak") }
+allow {
+    startswith(original_path, "/keycloak") 
+    not re_match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
+}
 allow { startswith(original_path, "/vcs") }
 
 # Allow cloud-init endpoints, as we do validation based on incoming IP.

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -53,7 +53,10 @@ original_body = o_path {
 #
 #     * VCS/Gitea
 #
-allow { startswith(original_path, "/keycloak") }
+allow {
+    startswith(original_path, "/keycloak")
+    not re_match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
+}
 allow { startswith(original_path, "/vcs") }
 allow { startswith(original_path, "/spire-jwks-") }
 # Allow cloud-init endpoints, as we do validation based on incoming IP.

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
@@ -31,6 +31,10 @@ test_user {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/uas-mgr/v1/", "headers": {"authorization": "Bearer {{ .userToken }}"}}}}}
 }
 
+test_ssrf {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/master/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
+}
+
 test_deny_admin {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/api1", "headers": {"authorization": "Bearer {{ .adminToken }}"}}}}}
 }

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
@@ -32,6 +32,10 @@ test_user {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/uas-mgr/v1/", "headers": {"authorization": "Bearer {{ .userToken }}"}}}}}
 }
 
+test_ssrf {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/master/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
+}
+
 test_admin {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/api1", "headers": {"authorization": "Bearer {{ .adminToken }}"}}}}}
 }


### PR DESCRIPTION
## Summary and Scope

CASMPET-6128: Break/Fix - Add opa policies to address keycloak vulnerabilities for request_uri and user access to admin paths

## Testing

Test logs are attached as file.
[CVE202010770MitigationTestLogs.txt](https://github.com/Cray-HPE/cray-opa/files/10114479/CVE202010770MitigationTestLogs.txt)

### Tested on:

mug.dev.cray.com

### Test description:

Gateway tests were run from inside and outside of mug.
Exploit provided for CVE was tested with and without the fix.
Unit test was added into regression and tested.

## Risks and Mitigations

The same fix is submitted for 1.2 release. The PR link is provided below for reference.
https://github.com/Cray-HPE/cray-opa/pull/71
