### PR TITLE
Addressed yaml indentation issue in customer-user policy

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.25.5
+version: 1.25.6
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
@@ -49,7 +49,7 @@ original_path = o_path {
 #     * VCS/Gitea
 #
 allow {
-    startswith(original_path, "/keycloak") 
+    startswith(original_path, "/keycloak")
     not re_match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
 }
 allow { startswith(original_path, "/vcs") }


### PR DESCRIPTION
## Summary and Scope
Found YAML indentation issue in the customer-user policy and addressed

### Tested on:

Changes are tested in the mug. And removed extra space in the line end.
Here is o/p in vi with set list.

```
#$
allow {$
    startswith(original_path, "/keycloak")$
    not re_match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)$
}$
allow { startswith(original_path, "/vcs") }$
$
# Allow cloud-init endpoints, as we do validation based on incoming IP.$
# In the future, these requests will come in via the TOR switches and ideally$
# not through the 'front door'.   This is an expansion to BSS.$
:set list
```
Chart will be installed after its generated. 

### Test description:

There is extra space at the end of line "startswith(original_path, "/keycloak")" which causes indentation issue in the config map.

