### PR TITLE
Restrict accessible Keycloak URIs via OPA Ingress Policy.

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: cray-opa
 sources:
 - https://github.com/Cray-HPE/cray-opa
-version: 1.10.8
+version: 1.10.9

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-admin.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-admin.tpl
@@ -44,16 +44,17 @@ original_path = o_path {
     o_path := http_request.path
 }
 
-# Whitelist Keycloak, since those services enable users to login and obtain
-# JWTs. vcs is also enabled here. Legacy services to be migrated or removed:
-#
-#     * VCS/Gitea
-#
+# Allow all access to Gitea/VCS
 allow {
-    any([
-        startswith(original_path, "/keycloak"),
-        startswith(original_path, "/vcs"),
-    ])
+    startswith(original_path, "/vcs")
+}
+
+# Allow all access to Keycloak, also apply mitigations
+allow
+{
+    startswith(original_path, "/keycloak")
+    # Mitigate CVE-2020-10770
+    not re_match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
 }
 
 # Allow cloud-init endpoints, as we do validation based on incoming IP.

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_test.rego.tpl
@@ -32,6 +32,11 @@ test_user {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/uas-mgr/v1/", "headers": {"authorization": "Bearer {{ .userToken }}"}}}}}
 }
 
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
+}
+
 test_admin {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/api1", "headers": {"authorization": "Bearer {{ .adminToken }}"}}}}}
 }

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-admin_policy_xforward_test.rego.tpl
@@ -32,6 +32,11 @@ test_user {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/uas-mgr/v1/", "headers": {"x-forwarded-access-token": "{{ .userToken }}"}}}}}
 }
 
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
+}
+
 test_admin {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/api1", "headers": {"x-forwarded-access-token": "{{ .adminToken }}"}}}}}
 }

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_test.rego.tpl
@@ -5,8 +5,17 @@ package istio.authz
 # allow.http_status is 403 when the request is rejected due to the default allow.
 # allow.http_status is not present the request is successful because the result is true.
 
+# Prevent broad access to /keycloak
 test_allow_bypassed_urls_with_no_auth_header {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/logout"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/token"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/userinfo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/certs"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/.well-known/openid-configuration"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/keycloak/resources/foo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/keycloak/resources/foo"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
@@ -32,8 +41,9 @@ test_user {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/uas-mgr/v1/", "headers": {"authorization": "Bearer {{ .userToken }}"}}}}}
 }
 
-test_ssrf {
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/master/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
 }
 
 test_deny_admin {

--- a/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway-customer-user_policy_xforward_test.rego.tpl
@@ -5,8 +5,17 @@ package istio.authz
 # allow.http_status is 403 when the request is rejected due to the default allow.
 # allow.http_status is not present the request is successful because the result is true.
 
+# Prevent prevent broad access to /keycloak
 test_allow_bypassed_urls_with_no_auth_header {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/logout"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/token"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/userinfo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/certs"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/.well-known/openid-configuration"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/keycloak/resources/foo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/keycloak/resources/foo"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
@@ -30,6 +39,11 @@ test_user_when_admin_required {
 
 test_user {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/uas-mgr/v1/", "headers": {"x-forwarded-access-token": "{{ .userToken }}"}}}}}
+}
+
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
 }
 
 test_deny_admin {

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.rego.tpl
@@ -5,8 +5,18 @@ package istio.authz
 # allow.http_status is 403 when the request is rejected due to the default allow.
 # allow.http_status is not present the request is successful because the result is true.
 
+# For keycloak. Limit broad /keycloak access to requests using the CMN LB
 test_allow_bypassed_urls_with_no_auth_header {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak", "host": "auth.cmn.acme.com"}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak", "host": "auth.nmnlb.acme.com"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/logout"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/token"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/userinfo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/certs"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/.well-known/openid-configuration"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/keycloak/resources/foo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/keycloak/resources/foo"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
@@ -32,8 +42,9 @@ test_user {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/uas-mgr/v1/", "headers": {"authorization": "Bearer {{ .userToken }}"}}}}}
 }
 
-test_ssrf {
-  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/master/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
 }
 
 test_admin {

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_test.xname_workloads.rego.tpl
@@ -5,8 +5,18 @@ package istio.authz
 # allow.http_status is 403 when the request is rejected due to the default allow.
 # allow.http_status is not present the request is successful because the result is true.
 
+# For keycloak. Limit broad /keycloak access to requests using the CMN LB
 test_allow_bypassed_urls_with_no_auth_header {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak", "host": "auth.cmn.acme.com"}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak", "host": "auth.nmnlb.acme.com"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/logout"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/token"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/userinfo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/certs"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/.well-known/openid-configuration"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/keycloak/resources/foo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/keycloak/resources/foo"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
@@ -30,6 +40,11 @@ test_user_when_admin_required {
 
 test_user {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/uas-mgr/v1/", "headers": {"authorization": "Bearer {{ .userToken }}"}}}}}
+}
+
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
 }
 
 test_admin {

--- a/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/ingressgateway_policy_xforward_test.rego.tpl
@@ -5,8 +5,18 @@ package istio.authz
 # allow.http_status is 403 when the request is rejected due to the default allow.
 # allow.http_status is not present the request is successful because the result is true.
 
+# For keycloak. Limit broad /keycloak access to requests using the CMN LB
 test_allow_bypassed_urls_with_no_auth_header {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak", "host": "auth.cmn.acme.com"}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak", "host": "auth.nmnlb.acme.com"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/logout"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/token"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/userinfo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/certs"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/.well-known/openid-configuration"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/keycloak/resources/foo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/keycloak/resources/foo"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
@@ -30,6 +40,11 @@ test_user_when_admin_required {
 
 test_user {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/uas-mgr/v1/", "headers": {"x-forwarded-access-token": "{{ .userToken }}"}}}}}
+}
+
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
 }
 
 test_admin {


### PR DESCRIPTION
Maintained duplicate test policy structure.

Resolves: CASMSEC-368

## Summary and Scope

Restrict accessible Keycloak application paths to a subset of those defined in Keycloak 9.0.0 OIDC endpoints (Shasta Realm), for all but requests that use the CMN LB (keyed by HTTP HOST attribute):

https://github.com/keycloak/keycloak-documentation/blob/9.0.0/securing_apps/topics/oidc/oidc-generic.adoc

The following end-points were not allowed due to lack of use cases in CSM:

* token introspection
* check session iframe
* registration endpoint

Cross-referenced requests against log traces from all istio ingress gateways on multiple systems. 

## Issues and Related PRs

* Resolves [CASMSEC-368](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-368)
* Change will also be needed in CSM 1.3.x ([CASMSEC-370](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-370)), main ([CASMSEC-371](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-371))

## Testing

* Tested using OPA unit tests, as updated. 
* Tested by applying policies to mug (a non-PoR (SW) 1.3.x system) and Wasp (CSM 1.2.1). 
* Tested deployment via helm chart upgrade and rollback on Wasp. 
* Tested Keycloak admin console login and browse on Wasp (via CMN LB).
* Executed `/usr/share/doc/csm/scripts/operations/gateway-test/ncn-gateway-test.sh` on Wasp before and after, verified passing. 
* Verified via one-shot script and proxied browsing (NMN, CHN) that /keycloak was not accessible (full application root) from the NMN or CHN on Wasp (keycloak not exposed via VS on HMN in CSM 1.2.1). 

### Tested on:

  * Mug, Wasp
  * Local development environment

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

* The RSA Token support was not tested. However, it's not clear if it is still in active use and the standard OIDC endpoints that are available should allow for continued use of the feature. Would need an environment to validate. 
* Policies should be tested against a full install, ideally, to verify no impact to install functionality. 
* If these policies should impact the system, a helm rollback can be performed to the previous version of OPA, sans the least (lesser) privilege protections. 

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

