### PR TITLE
Remove whitespace (spaces) from policy to have it render cleanly in configmaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ chart: chart_setup chart_package
 # grep command equals 0, patterns found, fail make
 # grep command != 0, patterns not found, succeed make
 check_policy_whitespace:
-		@echo 'Testing Policy for Whitespace'; sh -c "grep -ne '[\t ] $$' kubernetes/cray-opa/templates/_policy*.tpl && exit 1; exit 0"; exit $$?
+		@echo 'Testing Policy for Whitespace'; sh -c "grep -ne '[[:space:]]$$' kubernetes/cray-opa/templates/_policy*.tpl && exit 1; exit 0"; exit $$?
 
 chart_setup:
 		mkdir -p ${CHART_PATH}/.packaged

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,6 @@ all : check_policy_whitespace test chart
 test: chart_test rego_test
 chart: chart_setup chart_package
 
-# grep command equals 0, patterns found, fail make
-# grep command != 0, patterns not found, succeed make
 check_policy_whitespace:
 		@echo 'Testing Policy for Whitespace'; sh -c "grep -ne '[[:space:]]$$' kubernetes/cray-opa/templates/_policy*.tpl && exit 1; exit 0"; exit $$?
 

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,14 @@ CHART_VERSION ?= local
 
 HELM_UNITTEST_IMAGE ?= quintush/helm-unittest:3.3.0-0.2.5
 
-all : test chart
+all : check_policy_whitespace test chart
 test: chart_test rego_test
 chart: chart_setup chart_package
+
+# grep command equals 0, patterns found, fail make
+# grep command != 0, patterns not found, succeed make
+check_policy_whitespace:
+		@echo 'Testing Policy for Whitespace'; sh -c "grep -ne '[\t ] $$' kubernetes/cray-opa/templates/_policy*.tpl && exit 1; exit 0"; exit $$?
 
 chart_setup:
 		mkdir -p ${CHART_PATH}/.packaged

--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: cray-opa
 sources:
 - https://github.com/Cray-HPE/cray-opa
-version: 1.10.9
+version: 1.10.10

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway-customer-user.tpl
@@ -60,7 +60,7 @@ allow
         startswith(original_path, "/keycloak/realms/shasta/protocol/openid-connect/logout"),
         startswith(original_path, "/keycloak/realms/shasta/protocol/openid-connect/certs"),
         startswith(original_path, "/keycloak/realms/shasta/.well-known/openid-configuration")
-    ])   
+    ])
 }
 
 allow

--- a/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
+++ b/kubernetes/cray-opa/templates/_policy-ingressgateway.tpl
@@ -72,7 +72,7 @@ allow
         startswith(original_path, "/keycloak/realms/shasta/protocol/openid-connect/logout"),
         startswith(original_path, "/keycloak/realms/shasta/protocol/openid-connect/certs"),
         startswith(original_path, "/keycloak/realms/shasta/.well-known/openid-configuration")
-    ])   
+    ])
 }
 
 allow


### PR DESCRIPTION
Remove whitespace (spaces) from policy to have it render cleanly in configmaps. 

This doesn't impact functionality, but not having the fix will make editing the policies harder by administrators/developers. 

Add simple whitespace linting to Makefile to avoid issue in the future.

Resolves: CASMSEC-372
See Also: CASMSEC-368

## Summary and Scope

Remove whitespace (spaces) from policy to have it render cleanly in configmaps. 

This doesn't impact functionality, but not having the fix will make editing the policies harder by administrators/developers. 

Add simple whitespace linting to Makefile to avoid issue in the future.

## Issues and Related PRs

* Resolves [CASMSEC-372](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-372)
* Change will also be needed in release/1.3 and main

## Testing

(fanta)

1. Ran NCN gateway test (1.2.2)
2. Manually verified access to keycloak admin console on CMN, ensured it was inaccessible on NMN, CAN
3. Manually verified (scripted) a test of exposed OIDC endpoints across CMN, NMN, and CAN
4. Verified policies rendered cleanly (readability) 

### Tested on:

  * Fanta
  * Local development environment

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
