### PR TITLE
CASMSEC-370: Restrict accessible Keycloak URIs via OPA Ingress Policy

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.29.2
+version: 1.29.3
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/policies/hmn.yaml
+++ b/kubernetes/cray-opa/templates/policies/hmn.yaml
@@ -13,6 +13,7 @@ data:
   policy.rego: |-
     # HMN OPA Policy
     package istio.authz
+    import future.keywords.in
     import input.attributes.request.http as http_request
 
     # Whitelist traffic to HMS hmcollector
@@ -20,14 +21,37 @@ data:
         http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector-ingress.services.svc.cluster.local:80/*"
     }
 
-    # Whitelist Keycloak, since it allows users to login and obtain JWTs.
-    allow { startswith(original_path, "/keycloak") }
-
     # The path being requested from the user. When the envoy filter is configured for
     # SIDECAR_INBOUND this is: http_request.headers["x-envoy-original-path"].
     # When configured for GATEWAY this is http_request.path
     original_path = o_path {
         o_path := http_request.path
+    }
+
+    # Allow limited paths for Keycloak
+    allow
+    {
+        startswith(original_path, "/keycloak/realms/shasta/protocol/openid-connect/auth")
+        # Mitigate CVE-2020-10770
+        not re_match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
+    }
+
+    keycloak_oidc_paths := {
+    "/keycloak/realms/shasta/protocol/openid-connect/token",
+    "/keycloak/realms/shasta/protocol/openid-connect/userinfo",
+    "/keycloak/realms/shasta/protocol/openid-connect/logout",
+    "/keycloak/realms/shasta/protocol/openid-connect/certs",
+    "/keycloak/realms/shasta/.well-known/openid-configuration"
+    }
+
+    allow {
+    some x in keycloak_oidc_paths
+    startswith(original_path, x)
+    }
+
+    allow {
+    startswith(original_path, "/keycloak/resources")
+    http_request.method in {"GET", "HEAD"}
     }
 
 

--- a/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
@@ -45,7 +45,7 @@ data:
         o_path := http_request.path
     }
 
-    # Allow broad access to CMN LB for keycloak (CMN and NMN share Istio + OPA ingress stack in CSM 1.3.x), restrict to specific
+    # Allow broad access to CMN LB for keycloak (CMN and NMN share Istio + OPA ingress stack in CSM 1.4.x), restrict to specific
     # endpoints otherwise
 
     allow

--- a/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
@@ -14,6 +14,7 @@ data:
   policy.rego: |-
     # Keycloak Admin OPA Policy
     package istio.authz
+    import future.keywords.in
     import input.attributes.request.http as http_request
 
 
@@ -44,12 +45,41 @@ data:
         o_path := http_request.path
     }
 
-    # Whitelist Keycloak, since those services enable users to login and obtain
-    # JWTs. vcs is also enabled here. Legacy services to be migrated or removed:
-    #
-    #     * VCS/Gitea
-    #
-    allow { startswith(original_path, "/keycloak") }
+    # Allow broad access to CMN LB for keycloak (CMN and NMN share Istio + OPA ingress stack in CSM 1.3.x), restrict to specific
+    # endpoints otherwise
+
+    allow
+    {
+        startswith(original_path, "/keycloak")
+        startswith(http_request.host, "auth.cmn.")
+    }
+
+    allow
+    {
+        startswith(original_path, "/keycloak/realms/shasta/protocol/openid-connect/auth")
+        # Mitigate CVE-2020-10770
+        not re_match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
+    }
+
+    keycloak_oidc_paths := {
+    "/keycloak/realms/shasta/protocol/openid-connect/token",
+    "/keycloak/realms/shasta/protocol/openid-connect/userinfo",
+    "/keycloak/realms/shasta/protocol/openid-connect/logout",
+    "/keycloak/realms/shasta/protocol/openid-connect/certs",
+    "/keycloak/realms/shasta/.well-known/openid-configuration"
+    }
+
+    allow {
+    some x in keycloak_oidc_paths
+    startswith(original_path, x)
+    }
+
+    allow {
+    startswith(original_path, "/keycloak/resources")
+    http_request.method in {"GET", "HEAD"}
+    }
+
+    # Allow all access to Gitea
     allow { startswith(original_path, "/vcs") }
 
     # Allow cloud-init endpoints, as we do validation based on incoming IP.

--- a/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
@@ -59,8 +59,9 @@ data:
     http_request.method in {"GET", "HEAD"}
     }
 
-    # Allow all access to Gitea
+    # Allow all access to Gitea, Spire JWKS
     allow { startswith(original_path, "/vcs") }
+    allow { startswith(original_path, "/spire-jwks-") }
 
     # Allow cloud-init endpoints, as we do validation based on incoming IP.
     # In the future, these requests will come in via the TOR switches and ideally

--- a/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
@@ -25,7 +25,7 @@ data:
         o_path := http_request.path
     }
 
-    # Allow broad access to CMN LB for keycloak (CMN and NMN share Istio + OPA ingress stack in CSM 1.3.x), restrict to specific
+    # Allow broad access to CMN LB for keycloak (CMN and NMN share Istio + OPA ingress stack in CSM 1.4.x), restrict to specific
     # endpoints otherwise
 
     allow

--- a/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
@@ -14,8 +14,7 @@ data:
   policy.rego: |-
     # Keycloak System Gateway OPA Policy
     package istio.authz
-
-
+    import future.keywords.in
     import input.attributes.request.http as http_request
 
 
@@ -26,12 +25,41 @@ data:
         o_path := http_request.path
     }
 
-    # Whitelist Keycloak, since those services enable users to login and obtain
-    # JWTs. vcs is also enabled here. Legacy services to be migrated or removed:
-    #
-    #     * VCS/Gitea
-    #
-    allow { startswith(original_path, "/keycloak") }
+    # Allow broad access to CMN LB for keycloak (CMN and NMN share Istio + OPA ingress stack in CSM 1.3.x), restrict to specific
+    # endpoints otherwise
+
+    allow
+    {
+        startswith(original_path, "/keycloak")
+        startswith(http_request.host, "auth.cmn.")
+    }
+
+    allow
+    {
+        startswith(original_path, "/keycloak/realms/shasta/protocol/openid-connect/auth")
+        # Mitigate CVE-2020-10770
+        not re_match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
+    }
+
+    keycloak_oidc_paths := {
+    "/keycloak/realms/shasta/protocol/openid-connect/token",
+    "/keycloak/realms/shasta/protocol/openid-connect/userinfo",
+    "/keycloak/realms/shasta/protocol/openid-connect/logout",
+    "/keycloak/realms/shasta/protocol/openid-connect/certs",
+    "/keycloak/realms/shasta/.well-known/openid-configuration"
+    }
+
+    allow {
+    some x in keycloak_oidc_paths
+    startswith(original_path, x)
+    }
+
+    allow {
+    startswith(original_path, "/keycloak/resources")
+    http_request.method in {"GET", "HEAD"}
+    }
+
+    # Allow all access to Gitea
     allow { startswith(original_path, "/vcs") }
 
     # Allow cloud-init endpoints, as we do validation based on incoming IP.

--- a/kubernetes/cray-opa/templates/policies/keycloak-user.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-user.yaml
@@ -14,8 +14,7 @@ data:
   policy.rego: |-
     # Keycloak User Gateway OPA Policy
     package istio.authz
-
-
+    import future.keywords.in
     import input.attributes.request.http as http_request
 
     # Whitelist traffic to the Neuxs web UI since it uses Keycloak for authentication.
@@ -45,12 +44,33 @@ data:
         o_path := http_request.path
     }
 
-    # Whitelist Keycloak, since those services enable users to login and obtain
-    # JWTs. vcs are also enabled here. Legacy services to be migrated or removed:
-    #
-    #     * VCS/Gitea
-    #
-    allow { startswith(original_path, "/keycloak") }
+    # Allow limited paths for Keycloak
+    allow
+    {
+        startswith(original_path, "/keycloak/realms/shasta/protocol/openid-connect/auth")
+        # Mitigate CVE-2020-10770
+        not re_match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
+    }
+
+    keycloak_oidc_paths := {
+    "/keycloak/realms/shasta/protocol/openid-connect/token",
+    "/keycloak/realms/shasta/protocol/openid-connect/userinfo",
+    "/keycloak/realms/shasta/protocol/openid-connect/logout",
+    "/keycloak/realms/shasta/protocol/openid-connect/certs",
+    "/keycloak/realms/shasta/.well-known/openid-configuration"
+    }
+
+    allow {
+    some x in keycloak_oidc_paths
+    startswith(original_path, x)
+    }
+
+    allow {
+    startswith(original_path, "/keycloak/resources")
+    http_request.method in {"GET", "HEAD"}
+    }
+
+    # Allow all access to Gitea
     allow { startswith(original_path, "/vcs") }
 
     # Allow cloud-init endpoints, as we do validation based on incoming IP.

--- a/kubernetes/cray-opa/tests/opa/hmn_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/hmn_test.rego.tpl
@@ -5,17 +5,31 @@ package istio.authz
 # allow.http_status is 403 when the request is rejected due to the default allow.
 # allow.http_status is not present the request is successful because the result is true.
 
+# Limit broad access to keycloak. 
 test_allow_bypassed_urls_with_no_auth_header {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/logout"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/token"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/userinfo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/certs"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/.well-known/openid-configuration"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/keycloak/resources/foo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/keycloak/resources/foo"}}}}
 }
 
 test_deny_bypassed_urls_with_no_auth_header {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/capsules/"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/apis/gozerd/"}}}}
+}
+
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
 }
 
 test_deny_tokens_api {

--- a/kubernetes/cray-opa/tests/opa/keycloak-admin_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/keycloak-admin_test.rego.tpl
@@ -5,8 +5,18 @@ package istio.authz
 # allow.http_status is 403 when the request is rejected due to the default allow.
 # allow.http_status is not present the request is successful because the result is true.
 
+# Limit broad /keycloak access to requests using the CMN LB
 test_allow_bypassed_urls_with_no_auth_header {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak", "host": "auth.cmn.acme.com"}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak", "host": "auth.nmnlb.acme.com"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/logout"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/token"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/userinfo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/certs"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/.well-known/openid-configuration"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/keycloak/resources/foo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/keycloak/resources/foo"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
@@ -29,6 +39,11 @@ test_user_when_admin_required {
 
 test_user {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/uas-mgr/v1/", "headers": {"authorization": "Bearer {{ .userToken }}"}}}}}
+}
+
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
 }
 
 test_admin {

--- a/kubernetes/cray-opa/tests/opa/keycloak-system_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/keycloak-system_test.rego.tpl
@@ -21,7 +21,6 @@ test_allow_bypassed_urls_with_no_auth_header {
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-vshastaio/keys"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
 }
 
 test_user_when_admin_required {

--- a/kubernetes/cray-opa/tests/opa/keycloak-system_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/keycloak-system_test.rego.tpl
@@ -6,7 +6,16 @@ package istio.authz
 # allow.http_status is not present the request is successful because the result is true.
 
 test_allow_bypassed_urls_with_no_auth_header {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak", "host": "auth.cmn.acme.com"}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak", "host": "auth.nmnlb.acme.com"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/logout"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/token"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/userinfo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/certs"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/.well-known/openid-configuration"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/keycloak/resources/foo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/keycloak/resources/foo"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
@@ -17,6 +26,11 @@ test_user_when_admin_required {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/api1", "headers": {"authorization": "Bearer {{ .userToken }}"}}}}}
 }
 
+
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
+}
 # Tests for system-pxe role
 
 pxe_auth = "Bearer {{ .pxeToken }}"

--- a/kubernetes/cray-opa/tests/opa/keycloak-system_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/keycloak-system_test.rego.tpl
@@ -18,7 +18,9 @@ test_allow_bypassed_urls_with_no_auth_header {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/keycloak/resources/foo"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/spire-jwks-vshastaio/keys"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
 }
 

--- a/kubernetes/cray-opa/tests/opa/keycloak-user_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/keycloak-user_test.rego.tpl
@@ -5,8 +5,16 @@ package istio.authz
 # allow.http_status is 403 when the request is rejected due to the default allow.
 # allow.http_status is not present the request is successful because the result is true.
 
+# Limit broad /keycloak access to requests using the CMN LB
 test_allow_bypassed_urls_with_no_auth_header {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/logout"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/token"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/userinfo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/certs"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/.well-known/openid-configuration"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/keycloak/resources/foo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/keycloak/resources/foo"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
@@ -29,6 +37,11 @@ test_user_when_admin_required {
 
 test_user {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/uas-mgr/v1/", "headers": {"authorization": "Bearer {{ .userToken }}"}}}}}
+}
+
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
 }
 
 test_deny_admin {


### PR DESCRIPTION
Resolves: CASMSEC-370

## Summary and Scope

Restrict accessible Keycloak application paths to a subset of those defined in Keycloak 9.0.0 OIDC endpoints (Shasta Realm), for all but requests that use the CMN LB (keyed by HTTP HOST attribute):

https://github.com/keycloak/keycloak-documentation/blob/9.0.0/securing_apps/topics/oidc/oidc-generic.adoc

The following end-points were not allowed due to lack of use cases in CSM:

* token introspection
* check session iframe
* registration endpoint

Cross-referenced requests against log traces from all istio ingress gateways on multiple systems. 

As a delta to content in `release/1.3`, also ported the allow-listing in the `keycloak-system` policy/test after chatting with @kburns-hpe. 

## Issues and Related PRs

* Resolves [CASMSEC-370](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-370)
* Change already  in CSM 1.2.2 ([CASMSEC-368](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-368)), 1.3.1 ([CASMSEC-371](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-371))

## Testing

* Tested using OPA unit tests, as updated. 
* Tested by applying policies to Surtur (1.4 system)
* Tested deployment via helm chart upgrade and rollback on Surtur. 
* Tested Keycloak admin console login and browse on Surtur (via CMN LB).
* Executed `/usr/share/doc/csm/scripts/operations/gateway-test/ncn-gateway-test.sh` on Surtur before and after, verified passing. 
* Verified via one-shot script and proxied browsing that /keycloak was not accessible (full application root) from the NMN, HMN, or CAN on Surtur.

Upgrade Command/Results:

```
helm upgrade -n opa -f ./cray-opa-overrides.yaml cray-opa ./cray-opa
```

Values File:

```
global:
  chart:
    name: cray-opa
    version: 1.29.3
ingresses:
  ingressgateway:
    issuers:
      shasta-cmn: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta
      keycloak-cmn: https://auth.cmn.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta
      shasta-nmn: https://api.nmnlb.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta
      keycloak-nmn: https://auth.nmnlb.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta
  ingressgateway-customer-admin:
    issuers:
      shasta-cmn: https://api.cmn.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta
      keycloak-cmn: https://auth.cmn.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta
  ingressgateway-customer-user:
    issuers:
      shasta-can: https://api.can.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta
      keycloak-can: https://auth.can.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta
      shasta-chn: https://api.chn.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta
      keycloak-chn: https://auth.chn.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta
  ingressgateway-hmn:
    issuers:
      shasta-hmn: https://api.hmnlb.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta
      keycloak-hmn: https://auth.hmnlb.surtur.hpc.amslabs.hpecorp.net/keycloak/realms/shasta
```

### Tested on:

  * Surtur
  * Local development environment

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y (gateway test only due to shared use, other work on mug that would impact tests)
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

* The RSA Token support was not tested. However, it's not clear if it is still in active use and the standard OIDC endpoints that are available should allow for continued use of the feature. Would need an environment to validate. 
* Policies should be tested against a full install, ideally, to verify no impact to install functionality. 
* If these policies should impact the system, a helm rollback can be performed to the previous version of OPA, sans the least (lesser) privilege protections. 
* @ndavidson-hpe  notes that vShasta v1 isn't CMN aware for auth, so there may be an issue with backward compatibility. This was not evaluated tested for equivalent functionality already in 1.2.2 and 1.3.1. And, it seems like mis-alignment between vshasta and the CSM product in general. 

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [X] Target branch correct
- [x] Testing is appropriate and complete, if applicable