### PR TITLE
CASMPET-6279 Add support for multiple spire servers

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.30.0
+version: 1.31.0
 description: Cray Open Policy Agent
 keywords:
   - opa
@@ -32,9 +32,9 @@ sources:
   - https://github.com/Cray-HPE/cray-opa
 maintainers:
   - name: kburns-hpe
-appVersion: 0.42.0
+appVersion: 0.48.0
 annotations:
   artifacthub.io/images: |-
     - name: cray-opa
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.48.0-envoy
   artifacthub.io/license: MIT

--- a/kubernetes/cray-opa/examples/custom-keycloak.yaml
+++ b/kubernetes/cray-opa/examples/custom-keycloak.yaml
@@ -54,7 +54,7 @@ data:
     required_custom_roles[r] {
         perm := custom_role_perms[r][_]
         perm.method = http_request.method
-        re_match(perm.path, original_path)
+        regex.match(perm.path, original_path)
     }
 
     # Our list of endpoints we accept based on roles.

--- a/kubernetes/cray-opa/examples/custom-spire.yaml
+++ b/kubernetes/cray-opa/examples/custom-spire.yaml
@@ -56,7 +56,7 @@ data:
         # Test subject matches destination
         perm := custom_sub_match[s][_]
         perm.method = http_request.method
-        re_match(perm.path, original_path)
+        regex.match(perm.path, original_path)
     }
 
     custom_sub_match = {

--- a/kubernetes/cray-opa/templates/policies/hmn.yaml
+++ b/kubernetes/cray-opa/templates/policies/hmn.yaml
@@ -44,7 +44,7 @@ data:
     # If the auth type is bearer, decode the JWT
     parsed_kc_token = {"payload": payload} {
         found_auth.type == "Bearer"
-        response := http.send({"method": "get", "url": "{{ $.Values.jwtValidation.keycloak.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt"})
+        response := http.send({"method": "get", "url": "{{ $.Values.jwtValidation.keycloak.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt", "raise_error": false})
         [_, _, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "shasta"})
 
         # Verify that the issuer is as expected.

--- a/kubernetes/cray-opa/templates/policies/hmn.yaml
+++ b/kubernetes/cray-opa/templates/policies/hmn.yaml
@@ -66,7 +66,7 @@ data:
     required_roles[r] {
         perm := role_perms[r][_]
         perm.method = http_request.method
-        re_match(perm.path, original_path)
+        regex.match(perm.path, original_path)
     }
 
     # Our list of endpoints we accept based on roles.

--- a/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
@@ -94,7 +94,7 @@ data:
     # If the auth type is bearer, decode the JWT
     parsed_kc_token = {"payload": payload} {
         found_auth.type == "Bearer"
-        response := http.send({"method": "get", "url": "{{ $.Values.jwtValidation.keycloak.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt"})
+        response := http.send({"method": "get", "url": "{{ $.Values.jwtValidation.keycloak.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt", "raise_error": false})
         [_, _, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "shasta"})
 
         # Verify that the issuer is as expected.

--- a/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
@@ -115,7 +115,7 @@ data:
     required_admin_roles[r] {
         perm := admin_role_perms[r][_]
         perm.method = http_request.method
-        re_match(perm.path, original_path)
+        regex.match(perm.path, original_path)
     }
 
 

--- a/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
@@ -69,7 +69,7 @@ data:
     # If the auth type is bearer, decode the JWT
     parsed_kc_token = {"payload": payload} {
         found_auth.type == "Bearer"
-        response := http.send({"method": "get", "url": "{{ $.Values.jwtValidation.keycloak.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt"})
+        response := http.send({"method": "get", "url": "{{ $.Values.jwtValidation.keycloak.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt", "raise_error": false})
         [_, _, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "shasta"})
 
         # Verify that the issuer is as expected.

--- a/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
@@ -91,7 +91,7 @@ data:
     required_system_roles[r] {
         perm := system_role_perms[r][_]
         perm.method = http_request.method
-        re_match(perm.path, original_path)
+        regex.match(perm.path, original_path)
     }
 
 

--- a/kubernetes/cray-opa/templates/policies/keycloak-user.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-user.yaml
@@ -117,7 +117,7 @@ data:
     required_user_roles[r] {
         perm := user_role_perms[r][_]
         perm.method = http_request.method
-        re_match(perm.path, original_path)
+        regex.match(perm.path, original_path)
     }
 
 

--- a/kubernetes/cray-opa/templates/policies/keycloak-user.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-user.yaml
@@ -95,7 +95,7 @@ data:
     # If the auth type is bearer, decode the JWT
     parsed_kc_token = {"payload": payload} {
         found_auth.type == "Bearer"
-        response := http.send({"method": "get", "url": "{{ $.Values.jwtValidation.keycloak.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt"})
+        response := http.send({"method": "get", "url": "{{ $.Values.jwtValidation.keycloak.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt", "raise_error": false})
         [_, _, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "shasta"})
 
         # Verify that the issuer is as expected.

--- a/kubernetes/cray-opa/templates/policies/spire.yaml
+++ b/kubernetes/cray-opa/templates/policies/spire.yaml
@@ -146,13 +146,18 @@ data:
         ]
       }
 
+       verify_payload := payload {
+                response := [{{- range $.Values.jwtValidation.spire.jwksUris }}http.send({"method": "get", "url": "{{.}}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt", "raise_error": false}),{{- end }}]
+                [_, _, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response[_].raw_body, "aud": "system-compute"})
+      }
+
     {{- if $.Values.opa.xnamePolicy.enabled }}
     # Spire With XNAME Validation
     # If the auth type is bearer, decode the JWT
       parsed_spire_token = {"payload": payload, "xname": xname} {
           found_auth.type == "Bearer"
-          response := http.send({"method": "get", "url": "{{ $.Values.jwtValidation.spire.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt"})
-          [_, _, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "system-compute"})
+
+          payload = verify_payload
 
           # Verify that the issuer is as expected.
           allowed_issuers := [
@@ -218,8 +223,8 @@ data:
     # If the auth type is bearer, decode the JWT
     parsed_spire_token = {"payload": payload} {
         found_auth.type == "Bearer"
-        response := http.send({"method": "get", "url": "{{ $.Values.jwtValidation.spire.jwksUri }}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt"})
-        [_, _, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response.raw_body, "aud": "system-compute"})
+
+        payload := verify_payload
 
         # Verify that the issuer is as expected.
         allowed_issuers := [

--- a/kubernetes/cray-opa/templates/policies/spire.yaml
+++ b/kubernetes/cray-opa/templates/policies/spire.yaml
@@ -20,7 +20,11 @@ data:
   {{- end}}
       package istio.authz
       import input.attributes.request.http as http_request
+      import future.keywords.in
 
+
+    # Allow access to the spire jwks key data.
+      allow { startswith(original_path, "/spire-jwks") }
 
     # The path being requested from the user. When the envoy filter is configured for
     # SIDECAR_INBOUND this is: http_request.headers["x-envoy-original-path"].
@@ -146,9 +150,16 @@ data:
         ]
       }
 
+      isValid(resp) := p {
+        [v, _, p] := io.jwt.decode_verify(found_auth.token, {"cert": resp.raw_body, "aud": "system-compute"})
+        v == true
+      }
+
        verify_payload := payload {
-                response := [{{- range $.Values.jwtValidation.spire.jwksUris }}http.send({"method": "get", "url": "{{.}}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt", "raise_error": false}),{{- end }}]
-                [_, _, payload] := io.jwt.decode_verify(found_auth.token, {"cert": response[_].raw_body, "aud": "system-compute"})
+                responses := [{{- range $.Values.jwtValidation.spire.jwksUris }}http.send({"method": "get", "url": "{{.}}", "cache": true, "tls_ca_cert_file": "/jwtValidationFetchTls/certificate_authority.crt", "raise_error": false}),{{- end }}]
+
+                some response in responses
+                  payload := isValid(response)
       }
 
     {{- if $.Values.opa.xnamePolicy.enabled }}
@@ -177,7 +188,7 @@ data:
           # Test subject matches destination
           perm := sub_match[s][_]
           perm.method = http_request.method
-          re_match(perm.path, original_path)
+          regex.match(perm.path, original_path)
       }
 
       sub_match = {
@@ -243,7 +254,7 @@ data:
         # Test subject matches destination
         perm := sub_match[s][_]
         perm.method = http_request.method
-        re_match(perm.path, original_path)
+        regex.match(perm.path, original_path)
     }
 
     sub_match = {

--- a/kubernetes/cray-opa/tests/kuttl/custompolicy.yaml
+++ b/kubernetes/cray-opa/tests/kuttl/custompolicy.yaml
@@ -56,7 +56,7 @@ data:
     required_custom_roles[r] {
         perm := custom_role_perms[r][_]
         perm.method = http_request.method
-        re_match(perm.path, original_path)
+        perm.path = original_path
     }
 
     # Our list of endpoints we accept based on roles.

--- a/kubernetes/cray-opa/tests/opa/Dockerfile
+++ b/kubernetes/cray-opa/tests/opa/Dockerfile
@@ -35,7 +35,7 @@ RUN cd src/run_tests && go mod download
 RUN cd src/run_tests && go build .
 RUN ls src/run_tests
 
-FROM artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.42.1-envoy
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.48.0-envoy
 
 COPY --from=builder /go/src/run_tests/run_tests .
 COPY tests/opa/certificate_authority.crt /jwtValidationFetchTls/certificate_authority.crt

--- a/kubernetes/cray-opa/tests/opa/run_tests/run_tests.go
+++ b/kubernetes/cray-opa/tests/opa/run_tests/run_tests.go
@@ -463,7 +463,7 @@ func main() {
 						"jwksUri": ts.URL,
 					},
 					"spire": map[string]interface{}{
-						"jwksUri":     ts.URL,
+						"jwksUris":    []string{ts.URL},
 						"issuers":     []string{spireIssuer},
 						"trustDomain": "shasta",
 					},
@@ -479,7 +479,7 @@ func main() {
 						"jwksUri": ts.URL,
 					},
 					"spire": map[string]interface{}{
-						"jwksUri":     ts.URL,
+						"jwksUris":    []string{ts.URL},
 						"issuers":     []string{spireIssuer},
 						"trustDomain": "shasta",
 					},

--- a/kubernetes/cray-opa/tests/opa/spire_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/spire_test.rego.tpl
@@ -256,3 +256,17 @@ test_tpm_provisioner {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/tpm-provisioner/whitelist/remove", "headers": {"authorization": "Bearer {{ .spire.ncn.tpm_provisioner }}" }}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/tpm-provisioner/whitelist/remove", "headers": {"authorization": "Bearer {{ .spire.compute.tpm_provisioner }}" }}}}}
 }
+
+test_tpm_provisioner_cray_spire {
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/challenge/authorize?xname=x1&type=compute", "headers": {"authorization": "Bearer {{ .spire.compute.cray_tpm_provisioner }}" }}}}}
+
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/tpm-provisioner/challenge/request", "headers": {"authorization": "Bearer {{ .spire.compute.cray_tpm_provisioner }}" }}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/tpm-provisioner/challenge/submit", "headers": {"authorization": "Bearer {{ .spire.compute.cray_tpm_provisioner }}" }}}}}
+
+  # tpm-provisioner role should not have access to white list API
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/whitelist/get", "headers": {"authorization": "Bearer {{ .spire.compute.cray_tpm_provisioner }}" }}}}}
+
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/tpm-provisioner/whitelist/add", "headers": {"authorization": "Bearer {{ .spire.compute.cray_tpm_provisioner }}" }}}}}
+
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/tpm-provisioner/whitelist/remove", "headers": {"authorization": "Bearer {{ .spire.compute.cray_tpm_provisioner }}" }}}}}
+}

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -136,7 +136,9 @@ jwtValidation:
   keycloak:
     jwksUri: "https://istio-ingressgateway.istio-system.svc.cluster.local./keycloak/realms/shasta/protocol/openid-connect/certs"
   spire:
-    jwksUri: "http://spire-jwks.spire.svc.cluster.local/keys"
+    jwksUris:
+      - "http://spire-jwks.spire.svc.cluster.local/keys"
+      - "http://cray-spire-jwks.spire.svc.cluster.local/keys"
     issuers:
       vshasta.io: "http://spire.local/shasta/vshastaio"
     trustDomain: shasta

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -24,7 +24,7 @@
 ---
 image:
   repository: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa
-  tag: 0.42.1-envoy  # When changing this, also update tests/opa//Dockerfile.
+  tag: 0.48.0-envoy  # When changing this, also update tests/opa//Dockerfile.
   pullPolicy: IfNotPresent
 
 priorityClassName: csm-high-priority-service
@@ -141,4 +141,5 @@ jwtValidation:
       - "http://cray-spire-jwks.spire.svc.cluster.local/keys"
     issuers:
       vshasta.io: "http://spire.local/shasta/vshastaio"
+      crayspire.local: "http://crayspire.local/shasta"
     trustDomain: shasta


### PR DESCRIPTION
## Summary and Scope

This adds support for handling multiple jwks servers for spire.

## Issues and Related PRs

* Partially Resolves [CASMPET-6279](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6279) 
* 
## Testing

### Tested on:

  * Local development environment
  * surtur

### Test description:

Validates two spire servers were able to work concurrently.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? Y

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

