### PR TITLE
CASMPET-6366: Keycloak-Nexus integration regession

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.29.4
+version: 1.29.5
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
@@ -166,12 +166,12 @@ data:
       ],
       "system-nexus": [
         {"method": "GET", "path": `^/keycloak/admin/realms/shasta/clients/.*$`},
-        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/clients$`},
+        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/clients.*$`},
         {"method": "GET", "path": `^/keycloak/admin/realms/shasta/users/.*$`},
-        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/users$`},
+        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/users.*$`},
         {"method": "GET", "path": `^/keycloak/admin/realms/shasta/roles/.*$`},
-        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/roles$`},
-        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/groups$`},
+        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/roles.*$`},
+        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/groups.*$`},
       ],
     }
 

--- a/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
@@ -163,13 +163,23 @@ data:
         {"method": "POST", "path": `^/apis/hbtd/hmi/v1/heartbeat$`},
         {"method": "POST", "path": `^/apis/hbtd/hmi/v1/heartbeat/.*$`},
         {"method": "GET", "path": `^/apis/hbtd/hmi/v1/params$`},
-      ]
+      ],
+      "system-nexus": [
+        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/clients/.*$`},
+        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/clients$`},
+        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/users/.*$`},
+        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/users$`},
+        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/roles/.*$`},
+        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/roles$`},
+        {"method": "GET", "path": `^/keycloak/admin/realms/shasta/groups$`},
+      ],
     }
 
     # Our list of endpoints we accept based on roles.
     system_role_perms = {
       "system-pxe": allowed_system_methods["system-pxe"],
       "system-compute": allowed_system_methods["system-compute"],
+      "system-nexus": allowed_system_methods["system-nexus"],
     }
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary and Scope

This is a bug that was introduced with patching some security holes in Keycloak. The change blocked all authenticated traffic from Nexus to Keycloak for authentication of users on Nexus. The change added some more allowed endpoints for traffic with a system-nexus token. This should also be merged into main once testing has been done.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6366](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6366)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Drax with manual change to the config map and check.

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y 
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

No known risks currently


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

