### PR TITLE
CASMCMS-8436: Add OPA logic for new tenant-admin for BOS

### DIFF
--- a/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
@@ -128,12 +128,24 @@ data:
           {"method": "PATCH",  "path": `.*`},
           {"method": "HEAD",  "path": `.*`},
       ],
+      "tenant-admin": [
+          # BOS
+          {"method": "POST", "path": `^/apis/bos/v2/applystaged$`}, # POST allows tenants to continue booting specific components already staged
+          {"method": "GET",  "path": `^/apis/bos/v2/components$`}, # GET allows a listing of all active components states
+          {"method": "GET",  "path": `^/apis/bos/v2/components/.*$`}, # GET information on an individual component
+          {"method": "POST", "path": `^/apis/bos/v2/sessions$`}, # POST Creates a new BOSv2 Session
+          {"method": "GET",  "path": `^/apis/bos/v2/sessions/.*$`}, # GET allows monitoring status of individual sessions
+          {"method": "GET",  "path": `^/apis/bos/v2/sessions/.*?/status$`}, # Obtain more detailed status information for an individual session
+          {"method": "GET",  "path": `^/apis/bos/v2/sessiontemplates$`}, # GET BOSv2 SessionTemplates (list all)
+          {"method": "GET",  "path": `^/apis/bos/v2/sessiontemplates/.*?$`}, # GET BOSv2 SessionTemplates (obtain details about a specific session template)
+      ]
     }
 
     # Our list of endpoints we accept based on roles.
     # The admin roll can make any call.
     admin_role_perms = {
         "admin": allowed_admin_methods["admin"],
+        "tenant-admin": allowed_admin_methods["tenant-admin"],
     }
 
 {{- end }}


### PR DESCRIPTION
This mod grants several specific verb privilage to accounts that match the tenant-admin role. The tenant-admin role is applied to specific keycloak groups for individual tenants, and will be populated to the group automatically via tapms instantiation of tenants.

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

