### PR TITLE
CASMSEC-384: Restrict accessible Keycloak URIs via OPA Ingress Policy

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.32.4
+version: 1.32.5
 description: Cray Open Policy Agent
 keywords:
   - opa
@@ -32,9 +32,9 @@ sources:
   - https://github.com/Cray-HPE/cray-opa
 maintainers:
   - name: kburns-hpe
-appVersion: 0.48.0
+appVersion: 0.52.0
 annotations:
   artifacthub.io/images: |-
     - name: cray-opa
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.48.0-envoy
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
   artifacthub.io/license: MIT

--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/kubernetes/cray-opa/templates/policies/hmn.yaml
+++ b/kubernetes/cray-opa/templates/policies/hmn.yaml
@@ -13,15 +13,13 @@ data:
   policy.rego: |-
     # HMN OPA Policy
     package istio.authz
+    import future.keywords.in
     import input.attributes.request.http as http_request
 
     # Whitelist traffic to HMS hmcollector
     allow {
         http_request.headers["x-envoy-decorator-operation"] = "cray-hms-hmcollector-ingress.services.svc.cluster.local:80/*"
     }
-
-    # Whitelist Keycloak, since it allows users to login and obtain JWTs.
-    allow { startswith(original_path, "/keycloak") }
 
     # The path being requested from the user. When the envoy filter is configured for
     # SIDECAR_INBOUND this is: http_request.headers["x-envoy-original-path"].
@@ -30,6 +28,31 @@ data:
         o_path := http_request.path
     }
 
+    # Allow limited paths for Keycloak
+    allow
+    {
+        startswith(original_path, "/keycloak/realms/shasta/protocol/openid-connect/auth")
+        # Mitigate CVE-2020-10770
+        not regex.match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
+    }
+    
+    keycloak_oidc_paths := {
+    "/keycloak/realms/shasta/protocol/openid-connect/token",
+    "/keycloak/realms/shasta/protocol/openid-connect/userinfo",
+    "/keycloak/realms/shasta/protocol/openid-connect/logout",
+    "/keycloak/realms/shasta/protocol/openid-connect/certs",
+    "/keycloak/realms/shasta/.well-known/openid-configuration"
+    }
+
+    allow {
+        some x in keycloak_oidc_paths
+        startswith(original_path, x)
+    }
+
+    allow {
+        startswith(original_path, "/keycloak/resources")
+        http_request.method in {"GET", "HEAD"}
+    }
 
     allow {
         roles_for_user[r]

--- a/kubernetes/cray-opa/templates/policies/hmn.yaml
+++ b/kubernetes/cray-opa/templates/policies/hmn.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2022 Hewlett Packard Enterprise Development LP
+Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 */ -}}
 {{- range $name, $options := .Values.ingresses }}
 {{- if $options.policies.hmn }}

--- a/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
@@ -14,9 +14,8 @@ data:
   policy.rego: |-
     # Keycloak Admin OPA Policy
     package istio.authz
-    import input.attributes.request.http as http_request
     import future.keywords.in
-
+    import input.attributes.request.http as http_request
 
     # Whitelist traffic to the Neuxs web UI since it uses Keycloak for authentication.
     allow {
@@ -45,12 +44,40 @@ data:
         o_path := http_request.path
     }
 
-    # Whitelist Keycloak, since those services enable users to login and obtain
-    # JWTs. vcs is also enabled here. Legacy services to be migrated or removed:
-    #
-    #     * VCS/Gitea
-    #
-    allow { startswith(original_path, "/keycloak") }
+    # Allow broad access to CMN LB for keycloak (CMN and NMN share Istio + OPA ingress stack in CSM 1.4.x), restrict to specific
+    # endpoints otherwise
+    allow
+    {
+        startswith(original_path, "/keycloak")
+        startswith(http_request.host, "auth.cmn.")
+    }
+    
+    allow
+    {
+        startswith(original_path, "/keycloak/realms/shasta/protocol/openid-connect/auth")
+        # Mitigate CVE-2020-10770
+        not regex.match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
+    }
+
+    keycloak_oidc_paths := {
+    "/keycloak/realms/shasta/protocol/openid-connect/token",
+    "/keycloak/realms/shasta/protocol/openid-connect/userinfo",
+    "/keycloak/realms/shasta/protocol/openid-connect/logout",
+    "/keycloak/realms/shasta/protocol/openid-connect/certs",
+    "/keycloak/realms/shasta/.well-known/openid-configuration"
+    }
+
+    allow {
+        some x in keycloak_oidc_paths
+        startswith(original_path, x)
+    }
+
+    allow {
+        startswith(original_path, "/keycloak/resources")
+        http_request.method in {"GET", "HEAD"}
+    }
+
+    # Allow all access to Gitea
     allow { startswith(original_path, "/vcs") }
 
     # Allow cloud-init endpoints, as we do validation based on incoming IP.

--- a/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 */ -}}
 {{- range $name, $options := .Values.ingresses }}
 {{- if $options.policies.keycloak.admin }}

--- a/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
@@ -58,7 +58,7 @@ data:
       http_request.method in {"GET", "HEAD"}
     }
 
-    # Allow all access to Gitea, Spire JWKS
+    # Allow all access to Gitea
     allow { startswith(original_path, "/vcs") }
 
     # Allow cloud-init endpoints, as we do validation based on incoming IP.

--- a/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-system.yaml
@@ -14,8 +14,7 @@ data:
   policy.rego: |-
     # Keycloak System Gateway OPA Policy
     package istio.authz
-
-
+    import future.keywords.in
     import input.attributes.request.http as http_request
 
 
@@ -26,12 +25,40 @@ data:
         o_path := http_request.path
     }
 
-    # Whitelist Keycloak, since those services enable users to login and obtain
-    # JWTs. vcs is also enabled here. Legacy services to be migrated or removed:
-    #
-    #     * VCS/Gitea
-    #
-    allow { startswith(original_path, "/keycloak") }
+    # Allow broad access to CMN LB for keycloak (CMN and NMN share Istio + OPA ingress stack in CSM 1.4.x), restrict to specific
+    # endpoints otherwise
+    allow
+    {
+        startswith(original_path, "/keycloak")
+        startswith(http_request.host, "auth.cmn.")
+    }
+
+    allow
+    {
+        startswith(original_path, "/keycloak/realms/shasta/protocol/openid-connect/auth")
+        # Mitigate CVE-2020-10770
+        not regex.match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
+    }
+
+    keycloak_oidc_paths := {
+    "/keycloak/realms/shasta/protocol/openid-connect/token",
+    "/keycloak/realms/shasta/protocol/openid-connect/userinfo",
+    "/keycloak/realms/shasta/protocol/openid-connect/logout",
+    "/keycloak/realms/shasta/protocol/openid-connect/certs",
+    "/keycloak/realms/shasta/.well-known/openid-configuration"
+    }
+
+    allow {
+      some x in keycloak_oidc_paths
+      startswith(original_path, x)
+    }
+
+    allow {
+      startswith(original_path, "/keycloak/resources")
+      http_request.method in {"GET", "HEAD"}
+    }
+
+    # Allow all access to Gitea, Spire JWKS
     allow { startswith(original_path, "/vcs") }
 
     # Allow cloud-init endpoints, as we do validation based on incoming IP.

--- a/kubernetes/cray-opa/templates/policies/keycloak-user.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-user.yaml
@@ -14,8 +14,7 @@ data:
   policy.rego: |-
     # Keycloak User Gateway OPA Policy
     package istio.authz
-
-
+    import future.keywords.in
     import input.attributes.request.http as http_request
 
     # Whitelist traffic to the Neuxs web UI since it uses Keycloak for authentication.
@@ -45,12 +44,33 @@ data:
         o_path := http_request.path
     }
 
-    # Whitelist Keycloak, since those services enable users to login and obtain
-    # JWTs. vcs are also enabled here. Legacy services to be migrated or removed:
-    #
-    #     * VCS/Gitea
-    #
-    allow { startswith(original_path, "/keycloak") }
+    # Allow limited paths for Keycloak
+    allow
+    {
+        startswith(original_path, "/keycloak/realms/shasta/protocol/openid-connect/auth")
+        # Mitigate CVE-2020-10770
+        not regex.match(`^/keycloak/realms/[a-zA-Z0-9]+/protocol/openid-connect/.*request_uri=.*$`, original_path)
+    }
+
+    keycloak_oidc_paths := {
+    "/keycloak/realms/shasta/protocol/openid-connect/token",
+    "/keycloak/realms/shasta/protocol/openid-connect/userinfo",
+    "/keycloak/realms/shasta/protocol/openid-connect/logout",
+    "/keycloak/realms/shasta/protocol/openid-connect/certs",
+    "/keycloak/realms/shasta/.well-known/openid-configuration"
+    }
+    
+    allow {
+        some x in keycloak_oidc_paths
+        startswith(original_path, x)
+    }
+    
+    allow {
+        startswith(original_path, "/keycloak/resources")
+        http_request.method in {"GET", "HEAD"}
+    }
+
+    # Allow all access to Gitea
     allow { startswith(original_path, "/vcs") }
 
     # Allow cloud-init endpoints, as we do validation based on incoming IP.

--- a/kubernetes/cray-opa/tests/opa/hmn_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/hmn_test.rego.tpl
@@ -5,17 +5,31 @@ package istio.authz
 # allow.http_status is 403 when the request is rejected due to the default allow.
 # allow.http_status is not present the request is successful because the result is true.
 
+# Limit broad access to keycloak. 
 test_allow_bypassed_urls_with_no_auth_header {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/logout"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/token"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/userinfo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/certs"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/.well-known/openid-configuration"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/keycloak/resources/foo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/keycloak/resources/foo"}}}}
 }
 
 test_deny_bypassed_urls_with_no_auth_header {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/capsules/"}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/apis/gozerd/"}}}}
+}
+
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
 }
 
 test_deny_tokens_api {

--- a/kubernetes/cray-opa/tests/opa/keycloak-admin_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/keycloak-admin_test.rego.tpl
@@ -5,12 +5,27 @@ package istio.authz
 # allow.http_status is 403 when the request is rejected due to the default allow.
 # allow.http_status is not present the request is successful because the result is true.
 
+# Limit broad /keycloak access to requests using the CMN LB
 test_allow_bypassed_urls_with_no_auth_header {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak", "host": "auth.cmn.acme.com"}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak", "host": "auth.nmnlb.acme.com"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/logout"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/token"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/userinfo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/certs"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/.well-known/openid-configuration"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/keycloak/resources/foo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/keycloak/resources/foo"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/service/rest"}}}}
+}
+
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
 }
 
 test_deny_tokens_api {

--- a/kubernetes/cray-opa/tests/opa/keycloak-system_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/keycloak-system_test.rego.tpl
@@ -6,7 +6,16 @@ package istio.authz
 # allow.http_status is not present the request is successful because the result is true.
 
 test_allow_bypassed_urls_with_no_auth_header {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak", "host": "auth.cmn.acme.com"}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak", "host": "auth.nmnlb.acme.com"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/logout"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/token"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/userinfo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/certs"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/.well-known/openid-configuration"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/keycloak/resources/foo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/keycloak/resources/foo"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
@@ -15,6 +24,11 @@ test_allow_bypassed_urls_with_no_auth_header {
 
 test_user_when_admin_required {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/api1", "headers": {"authorization": "Bearer {{ .userToken }}"}}}}}
+}
+
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
 }
 
 # Tests for system-pxe role

--- a/kubernetes/cray-opa/tests/opa/keycloak-user_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/keycloak-user_test.rego.tpl
@@ -5,8 +5,16 @@ package istio.authz
 # allow.http_status is 403 when the request is rejected due to the default allow.
 # allow.http_status is not present the request is successful because the result is true.
 
+# Limit broad /keycloak access to requests using the CMN LB
 test_allow_bypassed_urls_with_no_auth_header {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/logout"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/token"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/userinfo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/certs"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/.well-known/openid-configuration"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/keycloak/resources/foo"}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/keycloak/resources/foo"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/vcs"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/repository"}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"path": "/v2"}}}}
@@ -25,6 +33,11 @@ test_deny_apis_with_no_auth_header {
 
 test_user_when_admin_required {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/api1", "headers": {"authorization": "Bearer {{ .userToken }}"}}}}}
+}
+
+# Mitigate CVE-2020-10770
+test_keycloak_cve_2020_10770 {
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"path": "/keycloak/realms/shasta/protocol/openid-connect/auth?scope=openid&response_type=code&redirect_uri=valid&state=cfx&nonce=cfx&client_id=security-admin-console&request_uri=http://hook.url'"}}}}
 }
 
 test_user {


### PR DESCRIPTION
## Summary and Scope

Restrict accessible Keycloak application paths to a subset of those defined in Keycloak 9.0.0 OIDC endpoints (Shasta Realm), for all but requests that use the CMN LB (keyed by HTTP HOST attribute):

https://github.com/keycloak/keycloak-documentation/blob/9.0.0/securing_apps/topics/oidc/oidc-generic.adoc

The following end-points were not allowed due to lack of use cases in CSM:

* token introspection
* check session iframe
* registration endpoint

Cross-referenced requests against log traces from all istio ingress gateways on multiple systems. 

## Issues and Related PRs

* Resolves [CASMSEC-384](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-384)
* Change already  in CSM 1.2.2 ([CASMSEC-368](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-368)), 1.3.1 ([CASMSEC-371](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-371)), and 1.4.0 ([CASMSEC-370](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-370))
* Doc PR to direct use of CMN for keycloak administrative actions, here: https://github.com/Cray-HPE/docs-csm/pull/3804

## Testing

* Tested using OPA unit tests, as updated. 

Testing performed against 1.4 port:

* Tested by applying policies to Surtur (1.4 system)
* Tested deployment via helm chart upgrade and rollback on Surtur. 
* Tested Keycloak admin console login and browse on Surtur (via CMN LB).
* Executed `/usr/share/doc/csm/scripts/operations/gateway-test/ncn-gateway-test.sh` on Surtur before and after, verified passing. 
* Verified via one-shot script and proxied browsing that /keycloak was not accessible (full application root) from the NMN, HMN, or CAN on Surtur.

### Tested on:

  * Surtur
  * Local development environment

Will also test as chart once published before promotion to CSM repo, as releasable content also includes https://github.com/Cray-HPE/cray-opa/pull/91. 

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y (gateway test only due to shared use, other work on mug that would impact tests)
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

* The RSA Token support was not tested. However, it's not clear if it is still in active use and the standard OIDC endpoints that are available should allow for continued use of the feature. Would need an environment to validate. 
* Policies should be tested against a full install, ideally, to verify no impact to install functionality. 
* If these policies should impact the system, a helm rollback can be performed to the previous version of OPA, sans the least (lesser) privilege protections. 
* @ndavidson-hpe  notes that vShasta v1 isn't CMN aware for auth, so there may be an issue with backward compatibility. This was not evaluated tested for equivalent functionality already in 1.2.2 and 1.3.1. And, it seems like mis-alignment between vshasta and the CSM product in general. 

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [X] Target branch correct
- [x] Testing is appropriate and complete, if applicable