### PR TITLE
CASMPET-6800: Update endpoints for TPM

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.32.5
+version: 1.32.6
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/policies/spire.yaml
+++ b/kubernetes/cray-opa/templates/policies/spire.yaml
@@ -99,9 +99,9 @@ data:
         ],
         "tpm-provisioner": [
         {{- if and (eq $.Values.opa.xnamePolicy.tpmProvisioner true) (eq $.Values.opa.xnamePolicy.enabled true) }}
-            {"method": "GET", "path": sprintf("^/apis/tpm-provisioner/challenge/authorize?xname=%v&type=[A-Za-z0-9]*$", [parsed_spire_token.xname])},
+            {"method": "GET", "path": sprintf("^/apis/tpm-provisioner/authorize?xname=%v&type=[A-Za-z0-9]*$", [parsed_spire_token.xname])},
         {{- else}}
-            {"method": "GET", "path": `^/apis/tpm-provisioner/challenge/authorize.*$`},
+            {"method": "GET", "path": `^/apis/tpm-provisioner/authorize.*$`},
         {{- end}}
             {"method": "POST", "path": `^/apis/tpm-provisioner/challenge/request$`},
             {"method": "POST", "path": `^/apis/tpm-provisioner/challenge/submit$`},

--- a/kubernetes/cray-opa/tests/opa/spire_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/spire_test.rego.tpl
@@ -246,8 +246,8 @@ test_spire_invalid_sub {
 }
 
 test_tpm_provisioner {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/challenge/authorize?xname=ncnw001&type=ncn", "headers": {"authorization": "Bearer {{ .spire.ncn.tpm_provisioner }}" }}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/challenge/authorize?xname=x1&type=compute", "headers": {"authorization": "Bearer {{ .spire.compute.tpm_provisioner }}" }}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/authorize?xname=ncnw001&type=ncn", "headers": {"authorization": "Bearer {{ .spire.ncn.tpm_provisioner }}" }}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/authorize?xname=x1&type=compute", "headers": {"authorization": "Bearer {{ .spire.compute.tpm_provisioner }}" }}}}}
 
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/tpm-provisioner/challenge/request", "headers": {"authorization": "Bearer {{ .spire.ncn.tpm_provisioner }}" }}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/tpm-provisioner/challenge/submit", "headers": {"authorization": "Bearer {{ .spire.ncn.tpm_provisioner }}" }}}}}
@@ -313,7 +313,7 @@ test_wlm {
 }
 
 test_tpm_provisioner_cray_spire {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/challenge/authorize?xname=x1&type=compute", "headers": {"authorization": "Bearer {{ .spire.compute.cray_tpm_provisioner }}" }}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/authorize?xname=x1&type=compute", "headers": {"authorization": "Bearer {{ .spire.compute.cray_tpm_provisioner }}" }}}}}
 
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/tpm-provisioner/challenge/request", "headers": {"authorization": "Bearer {{ .spire.compute.cray_tpm_provisioner }}" }}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/tpm-provisioner/challenge/submit", "headers": {"authorization": "Bearer {{ .spire.compute.cray_tpm_provisioner }}" }}}}}

--- a/kubernetes/cray-opa/tests/opa/spire_xname_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/spire_xname_test.rego.tpl
@@ -34,6 +34,6 @@ test_spire_wrong_xname_subs {
 }
 
 test_tpm_provisioner_wrong_xname {
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/challenge/authorize?xname=invalid&type=ncn", "headers": {"authorization": "Bearer {{ .spire.ncn.tpm_provisioner }}" }}}}}
-  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/challenge/authorize?xname=invalid&type=compute", "headers": {"authorization": "Bearer {{ .spire.compute.tpm_provisioner }}" }}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/authorize?xname=invalid&type=ncn", "headers": {"authorization": "Bearer {{ .spire.ncn.tpm_provisioner }}" }}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/tpm-provisioner/authorize?xname=invalid&type=compute", "headers": {"authorization": "Bearer {{ .spire.compute.tpm_provisioner }}" }}}}}
 }


### PR DESCRIPTION
## Summary and Scope

This fixes the endpoint for the TPM-Provisioner server api to be the correct endpoint for the authorize endpoints

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6800](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6800)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Baldar

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

