### PR TITLE
ALT-683 Allow wlm role to create BOS sessions

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.32.6
+version: 1.32.7
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/policies/keycloak-user.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-user.yaml
@@ -59,12 +59,12 @@ data:
     "/keycloak/realms/shasta/protocol/openid-connect/certs",
     "/keycloak/realms/shasta/.well-known/openid-configuration"
     }
-    
+
     allow {
         some x in keycloak_oidc_paths
         startswith(original_path, x)
     }
-    
+
     allow {
         startswith(original_path, "/keycloak/resources")
         http_request.method in {"GET", "HEAD"}
@@ -170,6 +170,8 @@ data:
       "wlm": [
           # BOS - node boot
           {"method": "POST", "path": `^/apis/bos/v2/applystaged$`},
+          {"method": "GET", "path": `^/apis/bos/v2/sessions/.*$`},
+          {"method": "POST", "path": `^/apis/bos/v2/sessions$`},
           # SMD - hardware state query
           {"method": "GET",  "path": `^/apis/smd/hsm/v2/.*$`},
           {"method": "HEAD",  "path": `^/apis/smd/hsm/v2/.*$`},

--- a/kubernetes/cray-opa/tests/opa/keycloak-user_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/keycloak-user_test.rego.tpl
@@ -181,6 +181,8 @@ test_wlm {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/power-control/v1/transitions/test", "headers": {"authorization": wlm_auth}}}}}
   # BOS - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/bos/v2/applystaged", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/bos/v2/sessions/test", "headers": {"authorization": wlm_auth}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/bos/v2/sessions", "headers": {"authorization": wlm_auth}}}}}
   # BOS - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/bos/v1/session", "headers": {"authorization": wlm_auth}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/bos/v1/session", "headers": {"authorization": wlm_auth}}}}}
@@ -226,6 +228,8 @@ test_wlm_xforwarded {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/power-control/v1/transitions/test", "headers": {"x-forwarded-access-token": "{{ .wlmToken }}" }}}}}
   # BOS - allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/bos/v2/applystaged", "headers": {"x-forwarded-access-token": "{{ .wlmToken }}" }}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/bos/v2/sessions/test", "headers": {"x-forwarded-access-token": "{{ .wlmToken }}" }}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/bos/v2/sessions", "headers": {"x-forwarded-access-token": "{{ .wlmToken }}" }}}}}
   # BOS - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/bos/v1/session", "headers": {"x-forwarded-access-token": "{{ .wlmToken }}" }}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/bos/v1/session", "headers": {"x-forwarded-access-token": "{{ .wlmToken }}" }}}}}


### PR DESCRIPTION
## Summary and Scope

To implement the the PBS provisioning feature for the UK Met office, PBS must be able to create BOS sessions to boot nodes using specific BOS session templates. Add the endpoints needed to create a BOS v2 session and check on its progress to the wlm role.

## Issues and Related PRs

* Resolves [ALT-683](https://jira-pro.it.hpe.com:8443/browse/ALT-683)

## Testing

Tested with unit tests.

### Tested on:

  * Local development environment

### Test description:

Tested by running unit tests.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? No
- Was downgrade tested? If not, why? No
- Were new tests (or test issues/Jiras) created for this change? Yes

## Risks and Mitigations

If the wlm role's client secret is leaked, attackers could shutdown or reboot nodes on the system.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

