### PR TITLE
CAST-34306: avoid OPA pod port exhaustion

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.32.7
+version: 1.33.0
 description: Cray Open Policy Agent
 keywords:
   - opa
@@ -31,7 +31,8 @@ home: https://github.com/Cray-HPE/cray-opa
 sources:
   - https://github.com/Cray-HPE/cray-opa
 maintainers:
-  - name: kburns-hpe
+  - name: bo-quan
+  - name: ndavidson-hpe
 appVersion: 0.52.0
 annotations:
   artifacthub.io/images: |-

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -137,7 +137,7 @@ jwtValidation:
     jwksUri: "https://istio-ingressgateway.istio-system.svc.cluster.local./keycloak/realms/shasta/protocol/openid-connect/certs"
   spire:
     jwksUris:
-      - "http://spire-jwks.spire.svc.cluster.local/keys"
+      - "https://istio-ingressgateway.istio-system.svc.cluster.local./spire-jwks-vshastaio/keys"
       - "http://cray-spire-jwks.spire.svc.cluster.local/keys"
     issuers:
       vshasta.io: "http://spire.local/shasta/vshastaio"


### PR DESCRIPTION
## Summary and Scope

A previous 1.3.1 fix for CASMPET-6126 was not merged to later releases, causing OPA pod port exhaustion in large systems. This PR adds the previous 1.3.1 fix to CSM 1.6 release.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CAST-34306](https://jira-pro.it.hpe.com:8443/browse/CAST-34306)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

