### PR TITLE
ALT-828 Allow DRC2 calls with SPIRE

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.33.0
+version: 1.33.1
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/policies/spire.yaml
+++ b/kubernetes/cray-opa/templates/policies/spire.yaml
@@ -117,6 +117,11 @@ data:
             {"method": "HEAD", "path": `^/apis/jackaloped/.*$`},
             {"method": "POST", "path": `^/apis/jackaloped/.*$`},
             {"method": "DELETE", "path": `^/apis/jackaloped/.*$`},
+            # ogopogod - DRC2
+            {"method": "GET", "path": `^/apis/ogopogod/.*$`},
+            {"method": "HEAD", "path": `^/apis/ogopogod/.*$`},
+            {"method": "POST", "path": `^/apis/ogopogod/.*$`},
+            {"method": "DELETE", "path": `^/apis/ogopogod/.*$`},
         ],
         "heartbeat": [
         {{- if and (eq $.Values.opa.xnamePolicy.heartbeat true) (eq $.Values.opa.xnamePolicy.enabled true) }}

--- a/kubernetes/cray-opa/tests/opa/spire_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/spire_test.rego.tpl
@@ -310,6 +310,13 @@ test_wlm {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": spire_sub}}}}}
   # jackaloped - not allowed
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/jackaloped/fabric/nics", "headers": {"authorization": spire_sub}}}}}
+  # ogopogod - allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/ogopogod/partitions", "headers": {"authorization": spire_sub}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": "/apis/ogopogod/partitions", "headers": {"authorization": spire_sub}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/ogopogod/partitions", "headers": {"authorization": spire_sub}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/ogopogod/partitions", "headers": {"authorization": spire_sub}}}}}
+  # ogopogod - not allowed
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/ogopogod/partitions", "headers": {"authorization": spire_sub}}}}}
 }
 
 test_tpm_provisioner_cray_spire {


### PR DESCRIPTION
## Summary and Scope

The DRC2 feature uses a new "ogopogod" API with SPIRE. Add this to the OPA policy to enable this feature.

## Issues and Related PRs

* Resolves [ALT-828](https://jira-pro.it.hpe.com:8443/browse/ALT-828)

## Testing

### Tested on:

  * Local development environment

### Test description:

Tested with unit tests.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? No
- Was downgrade tested? If not, why? No
- Were new tests (or test issues/Jiras) created for this change? Yes

## Risks and Mitigations

If the WLM SPIRE client secret is leaked, the attacker will be able to configure DRC2 VNIs on the system. This can be mitigated by revoking and regenerating the WLM client secret.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

