### PR TITLE
CASMPET-6883: remove CPU limit

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.29.6
+version: 1.29.7
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -108,7 +108,6 @@ opa:
       cpu: "250m"
     limits:
       memory: "10Gi"
-      cpu: "4"
   # Timeout defaults to 200ms if not specified. Setting it to 20s, an
   # arbitrary long timeout, provides sufficient overhead to resolve
   # CASMPET-1804/2570 "deadline exceeded" gRPC errors for the ext_authz filter.


### PR DESCRIPTION
## Summary and Scope

Due to the CPU limit set, some customers ran into 503 UAEX errors in a scale environment because OPA could not handle lots of simultaneous requests due to CPU throttling. This PR removes CPU limit for cray-opa to avoid this issue.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6883](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6883)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * by NERSC

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

