### PR TITLE
DVS-2961: Allow System Layout Service calls to generate the DVS node map

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.33.2
+version: 1.33.3
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/policies/spire.yaml
+++ b/kubernetes/cray-opa/templates/policies/spire.yaml
@@ -84,6 +84,10 @@ data:
           {"method": "GET",   "path": `^/apis/smd/hsm/v2/.*$`},
           {"method": "HEAD",  "path": `^/apis/smd/hsm/v2/.*$`},
 
+          #SLS -> GET - node map IP addresses
+          {"method": "GET",   "path": `^/apis/sls/v1/.*$`},
+          {"method": "HEAD",  "path": `^/apis/sls/v1/.*$`},
+
           #HMNFD -> subscribe only, cannot create state change notifications
           {"method": "GET",   "path": `^/apis/hmnfd/hmi/v1/subscriptions$`},
           {"method": "HEAD",  "path": `^/apis/hmnfd/hmi/v1/subscriptions$`},

--- a/kubernetes/cray-opa/templates/policies/spire.yaml
+++ b/kubernetes/cray-opa/templates/policies/spire.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 */ -}}
 {{- range $name, $options := .Values.ingresses }}
 {{- if $options.policies.spire }}

--- a/kubernetes/cray-opa/tests/opa/spire_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/spire_test.rego.tpl
@@ -57,7 +57,7 @@ spire_correct_ncn_sub(sub) {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": smd_softwarestatus_ncn_path, "headers": {"authorization": sub}}}}}
 
   # Validate that DVS can access SoftwareStatus
-  # not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v2/State/Components/ncnw001/SoftwareStatus", "headers": {"authorization": sub}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v2/State/Components/ncnw001/SoftwareStatus", "headers": {"authorization": sub}}}}}
 
   # SLS - Allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": sls_networks_path, "headers": {"authorization": sub}}}}}

--- a/kubernetes/cray-opa/tests/opa/spire_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/spire_test.rego.tpl
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 package istio.authz
 ## HOW TO DO UNIT TESTING

--- a/kubernetes/cray-opa/tests/opa/spire_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/spire_test.rego.tpl
@@ -13,9 +13,11 @@ cos_config_mock_path = "/apis/v2/cos/mock"
 hbtb_heartbeat_path = "/apis/hbtd/hmi/v1/heartbeat"
 nmd_mock_path = "/apis/v2/nmd/status"
 smd_statecomponents_path = "/apis/smd/hsm/v2/State/Components"
+smd_ethernetinterfaces_path = "/apis/smd/hsm/v2/Inventory/EthernetInterfaces"
 smd_softwarestatus_compute_path = "/apis/smd/hsm/v2/State/Components/x1/SoftwareStatus"
 smd_softwarestatus_ncn_path = "/apis/smd/hsm/v2/State/Components/ncnw001/SoftwareStatus"
 smd_softwarestatus_invalid_path = "/apis/smd/hsm/v2/State/Components/invalid/SoftwareStatus"
+sls_networks_path = "/apis/sls/v1/networks"
 hmnfd_subscribe_path = "/apis/hmnfd/hmi/v1/subscribe"
 hmnfd_subscriptions_path = "/apis/hmnfd/hmi/v1/subscriptions"
 pals_mock_path = "/apis/pals/v1/mock"
@@ -46,11 +48,22 @@ spire_correct_ncn_sub(sub) {
 
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": nmd_mock_path, "headers": {"authorization": sub}}}}}
 
+  # SMD - Allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": sub}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": sub}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_ethernetinterfaces_path, "headers": {"authorization": sub}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_ethernetinterfaces_path, "headers": {"authorization": sub}}}}}
 
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": smd_softwarestatus_ncn_path, "headers": {"authorization": sub}}}}}
 
+  # Validate that DVS can access SoftwareStatus
+  # not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v2/State/Components/ncnw001/SoftwareStatus", "headers": {"authorization": sub}}}}}
+
+  # SLS - Allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": sls_networks_path, "headers": {"authorization": sub}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": sls_networks_path, "headers": {"authorization": sub}}}}}
+
+  # HMNFD - Allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": hmnfd_subscriptions_path, "headers": {"authorization": sub}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": hmnfd_subscriptions_path, "headers": {"authorization": sub}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": hmnfd_subscribe_path, "headers": {"authorization": sub}}}}}
@@ -69,10 +82,6 @@ spire_correct_ncn_sub(sub) {
 
   # Validate that only CFS can access
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": cfs_ncn_mock_path, "headers": {"authorization": sub}}}}}
-
-  # Validate that DVS can access SoftwareStatus
-  # not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/smd/hsm/v2/State/Components/ncnw001/SoftwareStatus", "headers": {"authorization": sub}}}}}
-
 }
 
 spire_correct_compute_sub(sub) {
@@ -87,11 +96,17 @@ spire_correct_compute_sub(sub) {
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": nmd_mock_path, "headers": {"authorization": sub}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "POST", "path": nmd_mock_path, "headers": {"authorization": sub}}}}}
 
+  # SMD - Allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": smd_statecomponents_path, "headers": {"authorization": sub}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": smd_statecomponents_path, "headers": {"authorization": sub}}}}}
 
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": smd_softwarestatus_compute_path, "headers": {"authorization": sub}}}}}
 
+  # SLS - Allowed
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": sls_networks_path, "headers": {"authorization": sub}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": sls_networks_path, "headers": {"authorization": sub}}}}}
+
+  # HMNFD - Allowed
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": hmnfd_subscriptions_path, "headers": {"authorization": sub}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "HEAD", "path": hmnfd_subscriptions_path, "headers": {"authorization": sub}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": hmnfd_subscribe_path, "headers": {"authorization": sub}}}}}


### PR DESCRIPTION
Adding policies for SLS under DVS to allow the dvs_generate_map script to use the data from SLS to generate the node map.

Tested the change by editing the opa-policy-ingressgateway-spire config map and restarting pods. Verified that the SLS data is sent via the API when using a new valid token.

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
This PR pertains to new feature development to use SLS in the dvs_generate_map CSM script. Previously the script generates the DVS node map by doing host lookups for all nodes, causing a large increase in traffic at boot time. By sending only a few requests to SLS to get IP addresses instead, this greatly reduces the network traffic.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
This change is backwards compatible, it does not remove any current functionality or take away access from any already existing requests made to the HSM or otherwise - it only adds additional access to the SLS APIs via the Spire token.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

Resolves opened issue [CASMTRIAGE-6463] (https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6463)
Issue [DVS-2961] (https://jira-pro.it.hpe.com:8443/browse/DVS-2961) depends on [CASMTRIAGE-6463] (https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6463)

Work is required to complete the DVS feature [DVS-2961] (https://jira-pro.it.hpe.com:8443/browse/DVS-2961)


* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:
CSM 1.5 on Lemondrop (1.5.0-beta.70, compute-csm-1.5-5.2.34-x86_64, compute-csm-1.5-5.2.34-aarch64, cray-shasta-csm-sles15sp5-barebones-csm-1.5, secure-kubernetes-5.2.39-x86_64.squashfs)
CSM 1.4.3 on Groot (cray-shasta-csm-sles15sp4-barebones.x86_64-csm-1.4, secure-kubernetes-0.4.71-x86_64.squashfs)

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?
- 
Tested the change by editing the opa-policy-ingressgateway-spire config map and restarting pods. Verified that the SLS data is sent via the API when using a new valid token.
No code or behavior of previously accessed APIs was changed, and those tests were not yet otherwise exercised. Created additional tests for this change to ensure when tests are run that access has been made available to the SLS api.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
No known issues, the changes do not affect previous behavior.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

