### PR TITLE
CASMPET-6915: use newer plugin image and change it to daemonset

### DIFF
--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.32.9
+version: 1.32.10
 description: Cray Open Policy Agent
 keywords:
   - opa
@@ -33,9 +33,9 @@ sources:
 maintainers:
   - name: bo-quan
   - name: ndavidson-hpe
-appVersion: 0.52.0
+appVersion: 0.62.0
 annotations:
   artifacthub.io/images: |-
     - name: cray-opa
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
   artifacthub.io/license: MIT

--- a/kubernetes/cray-opa/templates/daemonset.yaml
+++ b/kubernetes/cray-opa/templates/daemonset.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -22,29 +22,28 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 */}}
 {{- range $name, $options:= .Values.ingresses }}
-{{ $uuid := uuidv4 }}
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: cray-opa-{{ $name }}
   namespace: {{ $.Release.Namespace }}
 spec:
-  replicas: {{ $.Values.opa.replicas }}
-  strategy:
+  updateStrategy:
     {{- $.Values.opa.strategy | toYaml | nindent 4}}
   selector:
     matchLabels:
+      daemonset: cray-opa-{{ $name }}
       app.kubernetes.io/name: cray-opa-{{ $name }}
       app.kubernetes.io/instance: {{ $.Release.Name }}
       app.kubernetes.io/managed-by: {{ $.Release.Service }}
   template:
     metadata:
       labels:
+        daemonset: cray-opa-{{ $name }}
         app.kubernetes.io/name: cray-opa-{{ $name }}
         app.kubernetes.io/instance: {{ $.Release.Name }}
         app.kubernetes.io/managed-by: {{ $.Release.Service }}
-        deployment/uuid: {{ $uuid }}
     spec:
       containers:
       - image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
@@ -151,34 +150,6 @@ spec:
       - configMap:
           name: cray-configmap-ca-public-key
         name: fetch-jwt-certs-ca-vol
-      affinity:
-      {{- if eq $.Values.affinity.default "preferred" }}
-        podAntiAffinity:
-           preferredDuringSchedulingIgnoredDuringExecution:
-           - weight: 1
-             podAffinityTerm:
-               labelSelector:
-                 matchExpressions:
-                 - key: app.kubernetes.io/name
-                   operator: In
-                   values:
-                   - cray-opa-{{ $name }}
-               topologyKey: kubernetes.io/hostname
-      {{- end }}
-      {{- if eq $.Values.affinity.default "required" }}
-        podAntiAffinity:
-           requiredDuringSchedulingIgnoredDuringExecution:
-             - labelSelector:
-                 matchExpressions:
-                 - key: deployment/uuid
-                   operator: In
-                   values:
-                   - {{ $uuid }}
-               topologyKey: kubernetes.io/hostname
-      {{- end }}
-      {{ if $options.affinity }}
-{{ toYaml $options.affinity | indent 8 }}
-      {{- end }}
       nodeSelector:
 {{ toYaml $.Values.nodeSelector | indent 8 }}
       tolerations:

--- a/kubernetes/cray-opa/templates/service.yaml
+++ b/kubernetes/cray-opa/templates/service.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -33,6 +33,7 @@ metadata:
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
 spec:
+  internalTrafficPolicy: {{ $.Values.opa.internalTrafficPolicy }}
   ports:
   - name: http
     port: {{ $.Values.opa.port }}

--- a/kubernetes/cray-opa/tests/opa/Dockerfile
+++ b/kubernetes/cray-opa/tests/opa/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,7 +37,7 @@ RUN cd src/run_tests && go mod download
 RUN cd src/run_tests && go build .
 RUN ls src/run_tests
 
-FROM artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.52.0-envoy-rootless
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
 WORKDIR /tmp
 COPY --from=builder --chown=1000:1000 /go/src/run_tests/run_tests .
 COPY --chown=1000:1000 tests/opa/certificate_authority.crt /jwtValidationFetchTls/certificate_authority.crt

--- a/kubernetes/cray-opa/values.yaml
+++ b/kubernetes/cray-opa/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,7 @@
 ---
 image:
   repository: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa
-  tag: 0.52.0-envoy-rootless  # When changing this, also update tests/opa//Dockerfile.
+  tag: 0.62.0-envoy-rootless  # When changing this, also update tests/opa/Dockerfile and precache image.
   pullPolicy: IfNotPresent
 
 priorityClassName: csm-high-priority-service
@@ -89,7 +89,7 @@ ingresses:
     issuers: []
 
 opa:
-  replicas: 3
+  internalTrafficPolicy: Local
   port: 9191
   containerPort: 9191
   loglevel: info
@@ -99,15 +99,14 @@ opa:
     secret: ""
   strategy:
     rollingUpdate:
-      maxSurge: 100%
-      maxUnavailable: 25%
+      maxUnavailable: 1
     type: RollingUpdate
   resources:
     requests:
       memory: "128Mi"
       cpu: "250m"
     limits:
-      memory: "10Gi"
+      memory: "800Mi"
   # Timeout defaults to 200ms if not specified. Setting it to 20s, an
   # arbitrary long timeout, provides sufficient overhead to resolve
   # CASMPET-1804/2570 "deadline exceeded" gRPC errors for the ext_authz filter.
@@ -125,11 +124,6 @@ opa:
     dvs: false
     heartbeat: false
     tpmProvisioner: false
-
-affinity:
-  # set default to 'preferred' for default preferred anti affinity rule
-  # set default to 'required' for default required anti affinity rule
-  default: required
 
 jwtValidation:
   keycloak:


### PR DESCRIPTION
## Summary and Scope

Due to limitations of server-side load balancing in kubernetes, especially with OPA as it uses GRPC protocol leveraging persistent connections, we often run into situations where only 1 or 2 OPA ingressgateway pods are used. This has exposed OPA memory leakage bug found in older OPA envoy plugin versions. This PR attempts to address the issue by changing OPA deployment to daemonset and uses a kubernetes beta feature that improves load balancing, in addition to using a newer OPA envoy plugin version v0.62.0 that has fixes for a memory leakage issue (https://github.com/open-policy-agent/opa/issues/5320).

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6915](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6915)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `fanta`
  * Local development environment
  * Virtual Shasta

### Test description:

Upgraded the chart, and verified that OPA has been changed to daemonset and is functioning as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

