### PR TITLE
CASMCMS-9239: Add OPA policies for tenant admins to CRUD CFS configurations

### DIFF
--- a/kubernetes/cray-opa/CHANGELOG.md
+++ b/kubernetes/cray-opa/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+- Tenant admins can access the CFS v3 configurations endpoint
 ### Changed
 - Reduce scope of WLM roles
 

--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.34.6
+version: 1.34.7
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 */ -}}
 {{- range $name, $options := .Values.ingresses }}
 {{- if $options.policies.keycloak.admin }}
@@ -207,7 +207,12 @@ data:
         {"method": "GET",  "path": `^/apis/bos/v2/sessions/.*?/status$`}, # Obtain more detailed status information for an individual session
         {"method": "GET",  "path": `^/apis/bos/v2/sessiontemplates$`}, # GET BOSv2 SessionTemplates (list all)
         {"method": "GET",  "path": `^/apis/bos/v2/sessiontemplates/.*?$`}, # GET BOSv2 SessionTemplates (obtain details about a specific session template)
-        {"method": "GET",  "path": `^/apis/bos/v2/version$`} # GETs allow views on specific BOS version information
+        {"method": "GET",  "path": `^/apis/bos/v2/version$`}, # GETs allow views on specific BOS version information
+        # CFS
+        {"method": "GET", "path": `^/apis/cfs/v3/configurations$`}, # GET allows listing one or all all configurations for this tenant
+        {"method": "PUT", "path": `^/apis/cfs/v3/configurations$`}, # PUT allows creating/overwriting a configuration
+        {"method": "PATCH", "path": `^/apis/cfs/v3/configurations$`}, # PATCH allows updating/overwriting a configuration
+        {"method": "DELETE", "path": `^/apis/cfs/v3/configurations$`} # DELETE allows deleting a configuration
     ]
 
     allowed_slingshot_admin_methods := [

--- a/kubernetes/cray-opa/tests/opa/keycloak-admin_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/keycloak-admin_test.rego.tpl
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 
 package istio.authz
 ## HOW TO DO UNIT TESTING
@@ -190,11 +190,16 @@ test_tenant_admin {
   # Verify infrastructure administrator has access to all endpoints, tenant header or not
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/bos/v2", "headers": {"authorization": "Bearer {{ .adminToken }}"}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/bos/v2", "headers": {"authorization": "Bearer {{ .adminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/cfs/v3/configurations", "headers": {"authorization": "Bearer {{ .adminToken }}"}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/cfs/v3/configurations", "headers": {"authorization": "Bearer {{ .adminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
+
 
   # Verify infrastructure administrator cannot supply an invalid tenant name
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/bos/v2", "headers": {"authorization": "Bearer {{ .adminToken }}", "cray-tenant-name": ""}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/cfs/v3/configurations", "headers": {"authorization": "Bearer {{ .adminToken }}", "cray-tenant-name": ""}}}}}
 
   # Verify tenant administrator (only authorized for vcluster-blue) can access valid endpoints
+  # BOS
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/bos/v2", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/bos/v2/applystaged", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/bos/v2/components", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
@@ -208,16 +213,24 @@ test_tenant_admin {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/bos/v2/sessiontemplates/foo", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "POST", "path": "/apis/bos/v2/sessions", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/bos/v2/version", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
+  # CFS
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/cfs/v3/configurations", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/cfs/v3/configurations", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/cfs/v3/configurations", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/cfs/v3/configurations", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
 
   # Verify tenant administrator cannot access unauthorized endpoints
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/api1", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
 
   # Verify tenant administrator cannot access a non-permitted tenant (vcluster-red)
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/bos/v2", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-red"}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/cfs/v3/configurations", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-red"}}}}}
 
   # Verify tenant administrator must supply a tenant header and cannot supply an invalid tenant name
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/bos/v2", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}"}}}}}
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/bos/v2", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": ""}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/cfs/v3/configurations", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}"}}}}}
+  allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/cfs/v3/configurations", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": ""}}}}}
 }
 
 # SPIRE Tests


### PR DESCRIPTION
## Summary and Scope

Add OPA policies for tenant admins to CRUD CFS configurations (v3 endpoint only).
Add corresponding tests.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-9239](issue link)
* This change should be released with the work being done in CASMCMS-9228.
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `tyr`

### Test description:
I created a tenant 'vcluster-green' through TAPMS and created and assigned a 'green' user to this cluster and made him a tenant admin. Before applying these changes, the green user could not access the cfs/v3/configurations endpoint. After applying them, he could.


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
None.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

