### PR TITLE
CASMCMS-9033 - add console endpoints for tenant admins.

### DIFF
--- a/kubernetes/cray-opa/CHANGELOG.md
+++ b/kubernetes/cray-opa/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - Tenant admins can access the CFS v3 configurations endpoint
+- Tenant admins can access the console endpoints
 ### Changed
 - Reduce scope of WLM roles
 

--- a/kubernetes/cray-opa/Chart.yaml
+++ b/kubernetes/cray-opa/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-opa
-version: 1.34.8
+version: 1.34.9
 description: Cray Open Policy Agent
 keywords:
   - opa

--- a/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
+++ b/kubernetes/cray-opa/templates/policies/keycloak-admin.yaml
@@ -213,7 +213,10 @@ data:
         {"method": "GET", "path": `^/apis/cfs/v3/configurations/.*$`}, # GET allows listing one configuration for this tenant	
         {"method": "PUT", "path": `^/apis/cfs/v3/configurations/.*$`}, # PUT allows creating/overwriting a configuration
         {"method": "PATCH", "path": `^/apis/cfs/v3/configurations/.*$`}, # PATCH allows updating/overwriting a configuration
-        {"method": "DELETE", "path": `^/apis/cfs/v3/configurations/.*$`} # DELETE allows deleting a configuration
+        {"method": "DELETE", "path": `^/apis/cfs/v3/configurations/.*$`}, # DELETE allows deleting a configuration
+        # Console
+        {"method": "GET", "path": `^/apis/console-operator/console-operator/tail/.*$`}, # GET initiates websocket connection to follow a console
+        {"method": "GET", "path": `^/apis/console-operator/console-operator/interact/.*$`} # GET initiates websocket connection to interact with a console
     ]
 
     allowed_slingshot_admin_methods := [

--- a/kubernetes/cray-opa/tests/opa/keycloak-admin_test.rego.tpl
+++ b/kubernetes/cray-opa/tests/opa/keycloak-admin_test.rego.tpl
@@ -218,6 +218,9 @@ test_tenant_admin {
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PUT", "path": "/apis/cfs/v3/configurations/mock", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "PATCH", "path": "/apis/cfs/v3/configurations/mock", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
   not allow.http_status with input as {"attributes": {"request": {"http": {"method": "DELETE", "path": "/apis/cfs/v3/configurations/mock", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
+  # Console
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/console-operator/console-operator/tail/foo", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
+  not allow.http_status with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/console-operator/console-operator/interact/foo", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}
 
   # Verify tenant administrator cannot access unauthorized endpoints
   allow.http_status == 403 with input as {"attributes": {"request": {"http": {"method": "GET", "path": "/apis/api1", "headers": {"authorization": "Bearer {{ .tenantAdminToken }}", "cray-tenant-name": "vcluster-blue"}}}}}


### PR DESCRIPTION
## Summary and Scope

Tenant admins need to be able to access the new console service endpoints to view console node logs and interact with node consoles.

## Issues and Related PRs
* Resolves [CASMCMS-9033](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9033)

## Testing
### Tested on:

  * `Mug`

### Test description:

I manually edited the opa template `opa-policy-ingressgateway-keycloak-admin` and restarted the opa services. I verified that a user set up as a tenant admin was able to access the console endpoints required.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Fairly low risk as this is only adding 2 newly created endpoints to the tenant admin permissions.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

